### PR TITLE
[helm] Ensure secret is created in k-rail namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ For the Helm deployment, all configuration for policies and exemptions are conta
 For Helm 2 and below, it is recommended to use `helm template` render the YAML for applying rather than usig Helm Tiller:
 
 ```bash
-helm template --namespace k-rail deploy/helm | kubectl apply -f - 
+helm template --namespace k-rail deploy/helm | kubectl apply -n k-rail -f -
 ```
 
 By default all policies are enforced (`report_only: false`).


### PR DESCRIPTION
Without `kubectl apply -n k-rail`, the secret was being created in default
namespace. Perhaps a glitch in helm v2.15.1.