### PR TITLE
enable dry run by specifying side effects

### DIFF
--- a/deploy/helm/templates/validatingwebhook.yaml
+++ b/deploy/helm/templates/validatingwebhook.yaml
@@ -31,6 +31,7 @@ webhooks:
           - cronjobs
           - ingresses
     failurePolicy: Ignore
+    sideEffects: None
     namespaceSelector:
       matchExpressions:
         - key: name


### PR DESCRIPTION
This enables `kubectl --server-dry-run` for clusters that support this alpha feature.

Signed-off-by: dustin-decker <dustindecker@protonmail.com>