### PR TITLE
Deploy improvements

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: k-rail
@@ -8,6 +8,9 @@ metadata:
     name: k-rail
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      name: k-rail
   template:
     metadata:
       name: k-rail

--- a/deploy/helm/templates/webhooks.yaml
+++ b/deploy/helm/templates/webhooks.yaml
@@ -1,8 +1,20 @@
 {{- $cn := printf "k-rail.%s.svc" .Release.Namespace }}
 {{- $ca := genCA "k-rail-admission-ca" 3650 -}}
 {{- $cert := genSignedCert $cn nil nil 3650 $ca -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: k-rail-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: k-rail-cert
+type: Opaque
+data:
+  cert.pem: {{ b64enc $cert.Cert }}
+  key.pem: {{ b64enc $cert.Key }}
+---
 apiVersion: admissionregistration.k8s.io/v1beta1
-kind: ValidatingWebhookConfiguration
+kind: MutatingWebhookConfiguration
 metadata:
   name: k-rail
   annotations:
@@ -30,7 +42,7 @@ webhooks:
           - jobs
           - cronjobs
           - ingresses
-    failurePolicy: Ignore
+    failurePolicy: {{ print .Values.failurePolicy }}
     sideEffects: None
     namespaceSelector:
       matchExpressions:
@@ -38,15 +50,3 @@ webhooks:
           operator: NotIn
           values: 
             - {{ .Release.Namespace }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: k-rail-cert
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app: k-rail-cert
-type: Opaque
-data:
-  cert.pem: {{ b64enc $cert.Cert }}
-  key.pem: {{ b64enc $cert.Key }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,6 +1,9 @@
 
 replicaCount: 3
 
+# Set this to 'Fail if you wish that resources apply fail if k-rail is unreachable.
+failurePolicy: Fail
+
 image:
   repository: cruise/k-rail
   tag: latest


### PR DESCRIPTION
- switches deployment to apps/v1
- makes the failurePolicy configurable, and defaults to 'Fail' rather than 'Ignore'
- changes the ValidatingWebhookConfiguration to a MutatingWebhookConfiguration in preparation for new mutating policies