### PR TITLE
Add no pod exec policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,12 @@ Since the violations are outputted as structured data, you are encouraged to agg
 
 # Supported policies
 
+## No Exec
+
+The No Exec policy prevents users from execing into running pods unless they have an exemption. This policy is typically enforced within a production environment, but run in report-only mode in dev and staging environments to facilitate debugging.
+
+Execing into a pod can enable someone to do many nefarious things to that workload. Eventually this policy will also apply a taint label to the Pod to indicate that it should no longer be trusted and can be evicted.
+
 ## No Bind Mounts
 
 Host bind mounts (also called `hostPath` mounts) can be used to exfiltrate data from or escalate privileges on the host system. Using host bind mounts can cause unreliability of the node if it causes a partition to fill up.

--- a/deploy/helm/templates/webhooks.yaml
+++ b/deploy/helm/templates/webhooks.yaml
@@ -29,7 +29,7 @@ webhooks:
         path: "/"
       caBundle: {{ b64enc $ca.Cert }}
     rules:
-      - operations: ["CREATE","UPDATE"]
+      - operations: ["CREATE","UPDATE","CONNECT"]
         apiGroups: ["*"]
         apiVersions: ["*"]
         resources: 
@@ -42,6 +42,7 @@ webhooks:
           - jobs
           - cronjobs
           - ingresses
+          - pods/exec
     failurePolicy: {{ print .Values.failurePolicy }}
     sideEffects: None
     namespaceSelector:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -36,6 +36,9 @@ config:
       - '^k8s.gcr.io/.*'               # official k8s GCR repo
       - '^[A-Za-z0-9\-:@]+$'           # official docker hub images
   policies:
+    - name: "pod_no_exec"
+      enabled: True
+      report_only: False
     - name: "pod_no_bind_mounts"
       enabled: True
       report_only: False

--- a/policies/pod/no_exec.go
+++ b/policies/pod/no_exec.go
@@ -1,0 +1,50 @@
+// Copyright 2019 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package ingress
+
+package pod
+
+import (
+	"context"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+
+	"github.com/cruise-automation/k-rail/policies"
+	"github.com/cruise-automation/k-rail/resource"
+)
+
+type PolicyNoExec struct{}
+
+func (p PolicyNoExec) Name() string {
+	return "pod_no_exec"
+}
+
+func (p PolicyNoExec) Validate(ctx context.Context, config policies.Config, ar *admissionv1beta1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
+
+	resourceViolations := []policies.ResourceViolation{}
+
+	podExecResource := resource.GetPodExecResource(ar)
+	if podExecResource == nil {
+		return resourceViolations, nil
+	}
+
+	violationText := "No pod exec: Execing into a Pod is forbidden without an exemption"
+
+	resourceViolations = append(resourceViolations, policies.ResourceViolation{
+		Namespace:    ar.Namespace,
+		ResourceName: podExecResource.ResourceName,
+		ResourceKind: podExecResource.ResourceKind,
+		Violation:    violationText,
+		Policy:       p.Name(),
+	})
+
+	return resourceViolations, nil
+}

--- a/resource/pod_exec.go
+++ b/resource/pod_exec.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package ingress
+
+package resource
+
+import (
+	"encoding/json"
+	"strings"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PodExecResource contains the information needed for processing by a Policy
+type PodExecResource struct {
+	Command      string
+	ResourceName string
+	ResourceKind string
+}
+
+// GetPodExecResource extracts and PodExecResource from an AdmissionRequest
+func GetPodExecResource(ar *admissionv1beta1.AdmissionRequest) *PodExecResource {
+	switch ar.Kind {
+	case metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "PodExecOptions"}:
+		podExecOptions := corev1.PodExecOptions{}
+		if err := json.Unmarshal(ar.Object.Raw, &podExecOptions); err != nil {
+			return nil
+		}
+		return &PodExecResource{
+			Command:      strings.Join(podExecOptions.Command, " "),
+			ResourceName: ar.Name,
+			ResourceKind: "PodExec",
+		}
+	default:
+		return nil
+	}
+}

--- a/server/policies.go
+++ b/server/policies.go
@@ -36,6 +36,7 @@ func (s *Server) registerPolicies() {
 	// Policies will be run in the order that they are registered.
 	// Policies that mutate will have their resulting patch merged with any previous patches in that order as well.
 
+	s.registerPolicy(pod.PolicyNoExec{})
 	s.registerPolicy(pod.PolicyBindMounts{})
 	s.registerPolicy(pod.PolicyDockerSock{})
 	s.registerPolicy(pod.PolicyImageImmutableReference{})


### PR DESCRIPTION
Adds a policy to block Pod execs unless there is an exemption.

Closes #8.

Signed-off-by: dustin-decker <dustindecker@protonmail.com>