### PR TITLE
Use numeric USER in Dockerfile for PSP compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN mkdir build; apk --no-cache add ca-certificates git make
 WORKDIR /go/src/github.com/cruise-automation/k-rail
 COPY ./ /build/
 RUN cd /build; make test; make build
+RUN useradd -u 10001 nobody && grep nobody /etc/passwd > /etc/passwd-nobody
 
 # Production image build stage
 FROM scratch
@@ -12,5 +13,6 @@ EXPOSE 8443/tcp
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /build/k-rail /k-rail
-USER nobody
+COPY --from=builder /etc/passwd-nobody /etc/passwd
+USER 10001
 ENTRYPOINT ["/k-rail", "-config", "/config/config.yml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ RUN mkdir build; apk --no-cache add ca-certificates git make
 WORKDIR /go/src/github.com/cruise-automation/k-rail
 COPY ./ /build/
 RUN cd /build; make test; make build
-RUN useradd -u 10001 nobody && grep nobody /etc/passwd > /etc/passwd-nobody
 
 # Production image build stage
 FROM scratch
@@ -13,6 +12,5 @@ EXPOSE 8443/tcp
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 COPY --from=builder /etc/passwd /etc/passwd
 COPY --from=builder /build/k-rail /k-rail
-COPY --from=builder /etc/passwd-nobody /etc/passwd
-USER 10001
+USER 65534
 ENTRYPOINT ["/k-rail", "-config", "/config/config.yml"]


### PR DESCRIPTION
Ironically, k-rail won't run in an environment where the default PodSecurityPolicies (PSP) enforce `RunAsNonRoot`, because the USER value in the Dockerfile is non-numeric:

```
  Warning  Failed     8s (x4 over 25s)   kubelet, wn3.kube-cluster.local  Error: container has runAsNonRoot and image has non-numeric user (nobody), cannot verify user is non-root
```

This PR simply changes the USER value to the UID of the "nobody" user, and makes PSP happy again :)