### PR TITLE
Add link to contributed published helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,14 @@ For Helm 2 and below, it is recommended to use `helm template` render the YAML f
 helm template --namespace k-rail deploy/helm | kubectl apply -f - 
 ```
 
+Until this project has its own helm chart repository, [a contributor](https://github.com/funkypenguin/helm-k-rail) has [published](http://funkypenguin.github.io/helm-charts/) the helm chart in this repo for easy installation, so an alternate helm-based installation would be:
+
+```bash
+helm repo add funkypenguin https://funkypenguin.github.io/helm-charts
+helm repo update
+helm template --namespace k-rail funkypenguin/k-rail | kubectl apply -f - 
+```
+
 By default all policies are enforced (`report_only: false`).
 
 Test the default configuration by applying the provided non-compliant deployment:


### PR DESCRIPTION
Hey guys, excellent work with k-rail! It's exactly in the sweet spot for what we need, but we install all our helm charts via repos. To aid installation, I've published your chart at http://funkypenguin.github.io/helm-charts/. Happy to discard this though, if you have your own helm chart repo :)