### PR TITLE
Add default seccomp policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ k-rail is a workload policy enforcement tool for Kubernetes. It can help you sec
   * [No Exec](#no-exec)
   * [No Bind Mounts](#no-bind-mounts)
   * [No Docker Sock Mount](#no-docker-sock-mount)
+  * [Mutate Default Seccomp Profile](#mutate-default-seccomp-profile)
+    + [Policy configuration](#policy-configuration)
   * [Immutable Image Reference](#immutable-image-reference)
   * [No Host Network](#no-host-network)
   * [No Host PID](#no-host-pid)
@@ -24,18 +26,18 @@ k-rail is a workload policy enforcement tool for Kubernetes. It can help you sec
   * [No Privileged Container](#no-privileged-container)
   * [No Helm Tiller](#no-helm-tiller)
   * [Trusted Image Repository](#trusted-image-repository)
-    + [Policy configuration](#policy-configuration)
+    + [Policy configuration](#policy-configuration-1)
   * [Safe to Evict (DEPRECATED)](#safe-to-evict--deprecated)
   * [Mutate Safe to Evict](#mutate-safe-to-evict)
   * [Require Ingress Exemption](#require-ingress-exemption)
-    + [Policy configuration](#policy-configuration-1)
+    + [Policy configuration](#policy-configuration-2)
 - [Configuration](#configuration)
   * [Logging](#logging)
   * [Modes of operation](#modes-of-operation)
     + [Global report-only mode](#global-report-only-mode)
     + [Policy modes](#policy-modes)
   * [Policy exemptions](#policy-exemptions)
-  * [Policy configuration](#policy-configuration-2)
+  * [Policy configuration](#policy-configuration-3)
 - [Adding new policies](#adding-new-policies)
 - [Debugging](#debugging)
   * [Resources are having timeout events](#resources-are-having-timeout-events)
@@ -45,7 +47,6 @@ k-rail is a workload policy enforcement tool for Kubernetes. It can help you sec
   * [Policies are enabled, but a deployment is blocked and an exemption is needed](#policies-are-enabled--but-a-deployment-is-blocked-and-an-exemption-is-needed)
   * [Checking the mTLS certificate expiration](#checking-the-mtls-certificate-expiration)
 - [License](#license)
-
 
 # Why k-rail?
 
@@ -218,6 +219,21 @@ Host bind mounts (also called `hostPath` mounts) can be used to exfiltrate data 
 The Docker socket bind mount provides API access to the host Docker daemon, which can be used for privilege escalation or otherwise control the container host. Using Docker sock mounts can cause unreliability of the node because of the extra workloads that the Kubernetes schedulers are not aware of.
 
 **Note:** It is recommended to use the `No Bind Mounts` policy to disable all `hostPath` mounts rather than only this policy.
+
+## Mutate Default Seccomp Profile
+
+Sets a default seccomp profile (`runtime/default` or a configured one) for Pods if they have no existing seccomp configuration. The default seccomp policy for Docker and Containerd both block over 40 syscalls, [many of which](https://docs.docker.com/engine/security/seccomp/#significant-syscalls-blocked-by-the-default-profile) are potentially dangerous. The default policies are [usually very compatible](https://blog.jessfraz.com/post/containers-security-and-echo-chambers/#breaking-changes) with applications, too.
+
+### Policy configuration
+
+The Mutate Default Seccomp Profile policy can be configured in the k-rail configuration file.
+
+Example
+
+```yaml
+policy_config:
+  policy_default_seccomp_policy: "runtime/default"
+```
 
 ## Immutable Image Reference
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -35,6 +35,7 @@ config:
     policy_trusted_repository_regexes:
       - '^k8s.gcr.io/.*'               # official k8s GCR repo
       - '^[A-Za-z0-9\-:@]+$'           # official docker hub images
+    policy_default_seccomp_policy: "runtime/default"
   policies:
     - name: "pod_no_exec"
       enabled: True
@@ -70,6 +71,9 @@ config:
       enabled: False
       report_only: True
     - name: "pod_mutate_safe_to_evict"
+      enabled: True
+      report_only: False
+    - name: "pod_default_seccomp_policy"
       enabled: True
       report_only: False
     - name: "ingress_require_ingress_exemption"

--- a/policies/config.go
+++ b/policies/config.go
@@ -19,4 +19,7 @@ type Config struct {
 	PolicyRequireIngressExemptionClasses []string `yaml:"policy_require_ingress_exemption_classes"`
 	// PolicyTrustedRepositoryRegexes contains regexes that match image repositories that you want to allow.
 	PolicyTrustedRepositoryRegexes []string `yaml:"policy_trusted_repository_regexes"`
+	// PolicyDefaultSeccompPolicy contains the seccomp policy that you want to be applied on Pods by default.
+	// Defaults to 'runtime/default'
+	PolicyDefaultSeccompPolicy string `yaml:"policy_default_seccomp_policy"`
 }

--- a/policies/pod/mutate_default_seccomp_policy.go
+++ b/policies/pod/mutate_default_seccomp_policy.go
@@ -1,0 +1,72 @@
+// Copyright 2019 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package ingress
+
+package pod
+
+import (
+	"context"
+
+	"github.com/cruise-automation/k-rail/policies"
+	"github.com/cruise-automation/k-rail/resource"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+)
+
+type PolicyDefaultSeccompPolicy struct{}
+
+func (p PolicyDefaultSeccompPolicy) Name() string {
+	return "pod_default_seccomp_policy"
+}
+
+func (p PolicyDefaultSeccompPolicy) Validate(ctx context.Context, config policies.Config, ar *admissionv1beta1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
+
+	podResource := resource.GetPodResource(ar)
+	if podResource == nil {
+		return nil, nil
+	}
+
+	var patches []policies.PatchOperation
+
+	seccompPolicy := config.PolicyDefaultSeccompPolicy
+	if len(seccompPolicy) == 0 {
+		seccompPolicy = "runtime/default"
+	}
+
+	if podResource.ResourceKind == "Pod" {
+		apply := true
+		for name := range podResource.PodAnnotations {
+			if name == "seccomp.security.alpha.kubernetes.io/pod" {
+				apply = false
+			}
+		}
+
+		if apply {
+			if podResource.PodAnnotations == nil {
+				patches = append(patches, policies.PatchOperation{
+					Op:   "add",
+					Path: "/metadata/annotations",
+					Value: map[string]string{
+						"seccomp.security.alpha.kubernetes.io/pod": seccompPolicy,
+					},
+				})
+			} else {
+				patches = append(patches, policies.PatchOperation{
+					Op: "replace",
+					// escape `/` in a path with ~1 in JSONPatch format 🤮
+					Path:  "/metadata/annotations/seccomp.security.alpha.kubernetes.io~1pod",
+					Value: seccompPolicy,
+				})
+			}
+		}
+	}
+
+	return nil, patches
+}

--- a/server/policies.go
+++ b/server/policies.go
@@ -48,6 +48,7 @@ func (s *Server) registerPolicies() {
 	s.registerPolicy(pod.PolicyNoHostPID{})
 	s.registerPolicy(pod.PolicySafeToEvict{})
 	s.registerPolicy(pod.PolicyMutateSafeToEvict{})
+	s.registerPolicy(pod.PolicyDefaultSeccompPolicy{})
 	s.registerPolicy(ingress.PolicyRequireIngressExemption{})
 }
 


### PR DESCRIPTION
This policy mutates pods to include a given Seccomp policy by default, unless an exemption is present.

Defaults to `runtime/default`.

```
seccomp.security.alpha.kubernetes.io/pod=runtime/default
```

Closes #15 

Signed-off-by: dustin-decker <dustindecker@protonmail.com>