### PR TITLE
Improve resource name extraction

### DIFF
--- a/deploy/non-compliant-daemonset.yaml
+++ b/deploy/non-compliant-daemonset.yaml
@@ -1,17 +1,16 @@
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
-  name: bad-deployment
+  name: bad-daemonset
 spec:
-  replicas: 1
   selector:
     matchLabels:
-      name: bad-deployment
+      name: bad-daemonset
   template:
     metadata:
       labels:
-        name: bad-deployment
+        name: bad-daemonset
     spec:
       hostNetwork: true
       hostPID: true
@@ -23,7 +22,7 @@ spec:
           hostPath:
             path: /
       containers:
-        - name: bad-deployment
+        - name: bad-daemonset
           image: ubuntu
           command: ["sleep", "36000"]
           imagePullPolicy: Always
@@ -36,5 +35,3 @@ spec:
             privileged: true
             capabilities:
               add: ["NET_ADMIN", "SYS_ADMIN"]
-
-

--- a/deploy/non-compliant-ingress.yaml
+++ b/deploy/non-compliant-ingress.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: bad-ingress
+  annotations:
+    kubernetes.io/ingress.class: public
+spec:
+  backend:
+    serviceName: bad-backend
+    servicePort: 666

--- a/resource/decoder.go
+++ b/resource/decoder.go
@@ -35,3 +35,31 @@ func decodeObject(raw []byte, object object) error {
 	}
 	return nil
 }
+
+// GetResourceName attempts to get the best name for a resource
+func GetResourceName(meta metav1.ObjectMeta) (name string) {
+	// Attempt to get the owner controller's resource name.
+	// This name is the high level resource that the user is working with.
+	for _, owner := range meta.OwnerReferences {
+		if owner.Controller != nil && *owner.Controller == true {
+			if len(owner.Name) > 0 {
+				name = owner.Name
+				return
+			}
+		}
+	}
+
+	// Attempt to get the object's name
+	if len(meta.Name) > 0 {
+		name = meta.Name
+		return
+	}
+
+	// Attempt to get the name label
+	if val, ok := meta.Labels["name"]; ok {
+		name = val
+		return
+	}
+
+	return
+}

--- a/resource/ingress.go
+++ b/resource/ingress.go
@@ -37,7 +37,7 @@ func GetIngressResource(ar *admissionv1beta1.AdmissionRequest) *IngressResource 
 		}
 		return &IngressResource{
 			IngressExt:   ing,
-			ResourceName: ing.Name,
+			ResourceName: GetResourceName(ing.ObjectMeta),
 			ResourceKind: "Ingress",
 		}
 	case metav1.GroupVersionResource{Group: "networking", Version: "v1beta1", Resource: "ingresses"}:
@@ -47,7 +47,7 @@ func GetIngressResource(ar *admissionv1beta1.AdmissionRequest) *IngressResource 
 		}
 		return &IngressResource{
 			IngressNet:   ing,
-			ResourceName: ing.Name,
+			ResourceName: GetResourceName(ing.ObjectMeta),
 			ResourceKind: "Ingress",
 		}
 	default:

--- a/resource/pod.go
+++ b/resource/pod.go
@@ -45,7 +45,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        pod.Spec,
 			PodAnnotations: pod.ObjectMeta.Annotations,
-			ResourceName:   pod.Name,
+			ResourceName:   GetResourceName(pod.ObjectMeta),
 			ResourceKind:   "Pod",
 		}
 	case metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "replicationcontrollers"}:
@@ -56,7 +56,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        rc.Spec.Template.Spec,
 			PodAnnotations: rc.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   rc.Name,
+			ResourceName:   GetResourceName(rc.ObjectMeta),
 			ResourceKind:   "ReplicationController",
 		}
 	case metav1.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "deployments"}:
@@ -67,7 +67,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        dep.Spec.Template.Spec,
 			PodAnnotations: dep.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   dep.Name,
+			ResourceName:   GetResourceName(dep.ObjectMeta),
 			ResourceKind:   "Deployment",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1beta1", Resource: "deployments"}:
@@ -78,7 +78,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        dep.Spec.Template.Spec,
 			PodAnnotations: dep.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   dep.Name,
+			ResourceName:   GetResourceName(dep.ObjectMeta),
 			ResourceKind:   "Deployment",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1beta2", Resource: "deployments"}:
@@ -89,7 +89,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        dep.Spec.Template.Spec,
 			PodAnnotations: dep.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   dep.Name,
+			ResourceName:   GetResourceName(dep.ObjectMeta),
 			ResourceKind:   "Deployment",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}:
@@ -100,7 +100,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        dep.Spec.Template.Spec,
 			PodAnnotations: dep.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   dep.Name,
+			ResourceName:   GetResourceName(dep.ObjectMeta),
 			ResourceKind:   "Deployment",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}:
@@ -111,7 +111,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        rs.Spec.Template.Spec,
 			PodAnnotations: rs.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   rs.Name,
+			ResourceName:   GetResourceName(rs.ObjectMeta),
 			ResourceKind:   "ReplicaSet",
 		}
 	case metav1.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "replicasets"}:
@@ -122,7 +122,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        rs.Spec.Template.Spec,
 			PodAnnotations: rs.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   rs.Name,
+			ResourceName:   GetResourceName(rs.ObjectMeta),
 			ResourceKind:   "ReplicaSet",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1beta2", Resource: "replicasets"}:
@@ -133,7 +133,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        rs.Spec.Template.Spec,
 			PodAnnotations: rs.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   rs.Name,
+			ResourceName:   GetResourceName(rs.ObjectMeta),
 			ResourceKind:   "ReplicaSet",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "daemonsets"}:
@@ -144,7 +144,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        ds.Spec.Template.Spec,
 			PodAnnotations: ds.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   ds.Name,
+			ResourceName:   GetResourceName(ds.ObjectMeta),
 			ResourceKind:   "DaemonSet",
 		}
 	case metav1.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "daemonsets"}:
@@ -155,7 +155,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        ds.Spec.Template.Spec,
 			PodAnnotations: ds.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   ds.Name,
+			ResourceName:   GetResourceName(ds.ObjectMeta),
 			ResourceKind:   "DaemonSet",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1beta2", Resource: "daemonsets"}:
@@ -166,7 +166,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        ds.Spec.Template.Spec,
 			PodAnnotations: ds.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   ds.Name,
+			ResourceName:   GetResourceName(ds.ObjectMeta),
 			ResourceKind:   "DaemonSet",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}:
@@ -177,7 +177,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        ss.Spec.Template.Spec,
 			PodAnnotations: ss.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   ss.Name,
+			ResourceName:   GetResourceName(ss.ObjectMeta),
 			ResourceKind:   "StatefulSet",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1beta1", Resource: "statefulsets"}:
@@ -188,7 +188,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        ss.Spec.Template.Spec,
 			PodAnnotations: ss.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   ss.Name,
+			ResourceName:   GetResourceName(ss.ObjectMeta),
 			ResourceKind:   "StatefulSet",
 		}
 	case metav1.GroupVersionResource{Group: "apps", Version: "v1beta2", Resource: "statefulsets"}:
@@ -199,7 +199,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        ss.Spec.Template.Spec,
 			PodAnnotations: ss.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   ss.Name,
+			ResourceName:   GetResourceName(ss.ObjectMeta),
 			ResourceKind:   "StatefulSet",
 		}
 	case metav1.GroupVersionResource{Group: "batch", Version: "v1", Resource: "jobs"}:
@@ -210,7 +210,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        job.Spec.Template.Spec,
 			PodAnnotations: job.Spec.Template.ObjectMeta.Annotations,
-			ResourceName:   job.Name,
+			ResourceName:   GetResourceName(job.ObjectMeta),
 			ResourceKind:   "Job",
 		}
 	case metav1.GroupVersionResource{Group: "batch", Version: "v1beta1", Resource: "cronjobs"}:
@@ -221,7 +221,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        job.Spec.JobTemplate.Spec.Template.Spec,
 			PodAnnotations: job.Spec.JobTemplate.ObjectMeta.Annotations,
-			ResourceName:   job.Name,
+			ResourceName:   GetResourceName(job.ObjectMeta),
 			ResourceKind:   "CronJob",
 		}
 	case metav1.GroupVersionResource{Group: "batch", Version: "v2alpha1", Resource: "cronjobs"}:
@@ -232,7 +232,7 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
 		return &PodResource{
 			PodSpec:        job.Spec.JobTemplate.Spec.Template.Spec,
 			PodAnnotations: job.Spec.JobTemplate.ObjectMeta.Annotations,
-			ResourceName:   job.Name,
+			ResourceName:   GetResourceName(job.ObjectMeta),
 			ResourceKind:   "CronJob",
 		}
 	default:


### PR DESCRIPTION
Fixes #23.

Improved resource name extraction with `GetResourceName()` which will attempt to retrieve the best resource name, in this order:

1. The name of the controller owner resource (DaemonSet in this case) `.metadata.ownerReferences.name`
1. The top-level `.name` field
1. A name label `.metadata.labels.name`