### PR TITLE
Add handler + policy + exemption integration test benchmarks

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -62,14 +61,10 @@ func Run(ctx context.Context) {
 		log.Fatal("error unmarshalling yaml config: ", err)
 	}
 
-	if strings.ToLower(cfg.LogLevel) == "debug" {
-		log.SetLevel(log.DebugLevel)
-	}
-	if strings.ToLower(cfg.LogLevel) == "warn" {
-		log.SetLevel(log.WarnLevel)
-	}
-	if strings.ToLower(cfg.LogLevel) == "info" {
-		log.SetLevel(log.InfoLevel)
+	if level, err := log.ParseLevel(cfg.LogLevel); err != nil {
+		log.SetLevel(level)
+	} else {
+		log.Fatal("invalid log level set: ", err)
 	}
 
 	var exemptions []policies.CompiledExemption

--- a/server/webhook_test.go
+++ b/server/webhook_test.go
@@ -16,6 +16,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	log "github.com/sirupsen/logrus"
+
 	"github.com/cruise-automation/k-rail/policies"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	authenticationv1 "k8s.io/api/authentication/v1"
@@ -24,7 +26,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-func TestServer_validateResources(t *testing.T) {
+type test struct {
+	name              string
+	resourceName      string
+	resourceNamespace string
+	podSpec           corev1.PodSpec
+	allow             bool
+}
+
+func test_setup() (Server, []test) {
 	rawExemptions := []policies.RawExemption{
 		{
 			ResourceName:   "test-resource",
@@ -50,15 +60,11 @@ func TestServer_validateResources(t *testing.T) {
 		Exemptions: compiledExemptions,
 	}
 
+	log.SetLevel(log.ErrorLevel)
+
 	testSrv.registerPolicies()
 
-	tests := []struct {
-		name              string
-		resourceName      string
-		resourceNamespace string
-		podSpec           corev1.PodSpec
-		allow             bool
-	}{
+	tests := []test{
 		{
 			name:  "deny by policy",
 			allow: false,
@@ -83,6 +89,61 @@ func TestServer_validateResources(t *testing.T) {
 			},
 		},
 	}
+
+	return testSrv, tests
+}
+
+func runBenchmark(b *testing.B, testSrv Server, tt test) {
+	pod := corev1.Pod{Spec: tt.podSpec}
+	pod.Name = tt.resourceName
+	raw, _ := json.Marshal(pod)
+	ar := admissionv1beta1.AdmissionReview{
+		Request: &admissionv1beta1.AdmissionRequest{
+			Namespace: tt.resourceNamespace,
+			Object:    runtime.RawExtension{Raw: raw},
+			Resource:  metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			UserInfo:  authenticationv1.UserInfo{Groups: []string{"group1"}},
+		},
+	}
+
+	if got := testSrv.validateResources(ar); got.Response.Allowed != tt.allow {
+		b.Errorf("Server.validateResources() = %v, want %v", got.Response.Allowed, tt.allow)
+	}
+}
+
+func BenchmarkServer_DenyPolicy(b *testing.B) {
+	testSrv, tests := test_setup()
+	tt := tests[0]
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			runBenchmark(b, testSrv, tt)
+		}
+	})
+}
+
+func BenchmarkServer_AllowPolicy(b *testing.B) {
+	testSrv, tests := test_setup()
+	tt := tests[1]
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			runBenchmark(b, testSrv, tt)
+		}
+	})
+}
+
+func BenchmarkServer_AllowExemption(b *testing.B) {
+	testSrv, tests := test_setup()
+	tt := tests[2]
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			runBenchmark(b, testSrv, tt)
+		}
+	})
+}
+
+func TestServer_validateResources(t *testing.T) {
+	testSrv, tests := test_setup()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			pod := corev1.Pod{Spec: tt.podSpec}


### PR DESCRIPTION
Run with default GOMAXPROCS parallelism on an old i7-7500U dual core laptop.

```
go test -benchmem -run=^$ github.com/cruise-automation/k-rail/server -bench .
goos: linux
goarch: amd64
pkg: github.com/cruise-automation/k-rail/server
BenchmarkServer_DenyPolicy-4       	   30000	     43715 ns/op	   50968 B/op	     228 allocs/op
BenchmarkServer_AllowPolicy-4      	   30000	     40958 ns/op	   49825 B/op	     206 allocs/op
BenchmarkServer_AllowExemption-4   	   30000	     46380 ns/op	   51208 B/op	     252 allocs/op
PASS
ok  	github.com/cruise-automation/k-rail/server	5.296s
```