### PR TITLE
Disallow ShareProcessNamespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ k-rail is a workload policy enforcement tool for Kubernetes. It can help you sec
   * [Violations from the Events API](#violations-from-the-events-api)
   * [Violations from logs](#violations-from-logs)
 - [Supported policies](#supported-policies)
+  * [No ShareProcessNamespace](#no-shareprocessnamespace)
   * [No Exec](#no-exec)
   * [No Bind Mounts](#no-bind-mounts)
   * [No Docker Sock Mount](#no-docker-sock-mount)
@@ -204,6 +205,14 @@ Since the violations are outputted as structured data, you are encouraged to agg
 
 
 # Supported policies
+
+## No ShareProcessNamespace
+
+`shareProcessNamespace: true` is a Pod Spec directive that puts all containers in a Pod within
+the same PID Namespace. When this occurs, containers can, for example, [access each others' filesystem and memory]
+(https://kubernetes.io/docs/tasks/configure-pod-container/share-process-namespace/#understanding-process-namespace-sharing),
+as long as they share user and group IDs. These effects could be unexpected, especially if security (e.g. egress controls)
+occurs in a sidecar container.
 
 ## No Exec
 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -76,6 +76,9 @@ config:
     - name: "pod_default_seccomp_policy"
       enabled: True
       report_only: False
+    - name: "pod_no_shareprocessnamespace"
+      enabled: True
+      report_only: False
     - name: "ingress_require_ingress_exemption"
       enabled: True
       report_only: False

--- a/policies/pod/no_shareprocessnamespace.go
+++ b/policies/pod/no_shareprocessnamespace.go
@@ -1,0 +1,52 @@
+// Copyright 2019 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package ingress
+
+package pod
+
+import (
+	"context"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+
+	"github.com/cruise-automation/k-rail/policies"
+	"github.com/cruise-automation/k-rail/resource"
+)
+
+type PolicyNoShareProcessNamespace struct{}
+
+func (p PolicyNoShareProcessNamespace) Name() string {
+	return "pod_no_shareprocessnamespace"
+}
+
+func (p PolicyNoShareProcessNamespace) Validate(ctx context.Context, config policies.Config, ar *admissionv1beta1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
+
+	resourceViolations := []policies.ResourceViolation{}
+
+	podResource := resource.GetPodResource(ar)
+	if podResource == nil {
+		return resourceViolations, nil
+	}
+
+	violationText := "No ShareProcessNamespace: sharing the process namespace among containers in a Pod is forbidden."
+
+	if *podResource.PodSpec.ShareProcessNamespace {
+		resourceViolations = append(resourceViolations, policies.ResourceViolation{
+			Namespace:    ar.Namespace,
+			ResourceName: podResource.ResourceName,
+			ResourceKind: podResource.ResourceKind,
+			Violation:    violationText,
+			Policy:       p.Name(),
+		})
+	}
+
+	return resourceViolations, nil
+}

--- a/policies/pod/no_shareprocessnamespace.go
+++ b/policies/pod/no_shareprocessnamespace.go
@@ -38,7 +38,7 @@ func (p PolicyNoShareProcessNamespace) Validate(ctx context.Context, config poli
 
 	violationText := "No ShareProcessNamespace: sharing the process namespace among containers in a Pod is forbidden."
 
-	if *podResource.PodSpec.ShareProcessNamespace {
+	if podResource.PodSpec.ShareProcessNamespace != nil {
 		resourceViolations = append(resourceViolations, policies.ResourceViolation{
 			Namespace:    ar.Namespace,
 			ResourceName: podResource.ResourceName,

--- a/server/policies.go
+++ b/server/policies.go
@@ -49,6 +49,7 @@ func (s *Server) registerPolicies() {
 	s.registerPolicy(pod.PolicySafeToEvict{})
 	s.registerPolicy(pod.PolicyMutateSafeToEvict{})
 	s.registerPolicy(pod.PolicyDefaultSeccompPolicy{})
+	s.registerPolicy(pod.PolicyNoShareProcessNamespace{})
 	s.registerPolicy(ingress.PolicyRequireIngressExemption{})
 }
 


### PR DESCRIPTION
Signed-off-by: Jack Leadford <jack.leadford@nccgroup.com>

See blurb in README.md. This PR adds a default policy that denies use of ShareProcessNamespace, which makes containers in a Pod share a PID namespace.