### PR TITLE
Add a mutate image pull policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ k-rail is a workload policy enforcement tool for Kubernetes. It can help you sec
     + [Policy configuration](#policy-configuration-2)
   * [Safe to Evict (DEPRECATED)](#safe-to-evict--deprecated)
   * [Mutate Safe to Evict](#mutate-safe-to-evict)
-  * [Mutate Image Pull Policy] (#mutate-image-pull-policy)
+  * [Mutate Image Pull Policy](#mutate-image-pull-policy)
   * [Require Ingress Exemption](#require-ingress-exemption)
     + [Policy configuration](#policy-configuration-3)
 - [Configuration](#configuration)
@@ -347,9 +347,10 @@ $ kubectl get po --all-namespaces -o json | jq -r '.items[] | select(.spec.volum
 
 There are cerntain images which require the enforcement of the ImagePullPolicy according to different user scenarios
 - IfNotPresent
-It can reduce the unnecessary traffic(Auth and Download requests) to Image repository and reuse the image which is cached on the node 
+It can reduce the unnecessary traffic (Auth and Download requests) to Image repository and reuse the image which is cached on the node 
 - Always
-It can be useful when there require the absolute isolation in multi-tenant cluster, which prevents others to reuse the image cached on the node, for example: The image protected with ImagePullSecret from private repository is cached on the node after first successful pull, other use can be directly pull from node without proper auth
+It can be useful when it requires the absolute isolation in multi-tenant cluster, which prevents others to reuse the image cached on the node, for example: The image protected with ImagePullSecret from private repository is cached on the node after first successful pull, other user can directly pull from node without proper auth.
+However if we force the imagePullPolicy to Always, it would fail without proper ImagePullSecret
 
 ### Policy configuration
 
@@ -360,8 +361,8 @@ Example
 policy_config:
   mutate_image_pull_policy:
     IfNotPresent: 
-      - '^gcr.io/cruise-gcr-prod/daytona.*'
-      - '^gcr.io/cruise-gcr-dev/daytona.*'
+      - '^gcr.io/repo/image1.*'
+      - '^gcr.io/repo/image2.*'
     Always:
       - '^gcr.io/private-repo/secretimage.*'
 ```

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -40,9 +40,8 @@ config:
       maximum_size_limit: "1Gi"
       default_size_limit: "512Mi"
     mutate_image_pull_policy:
-      IfNotPresent: 
-        - '^gcr.io/cruise-gcr-prod/daytona.*'
-        - '^gcr.io/cruise-gcr-dev/daytona.*'
+      IfNotPresent: []
+      Always: []
   policies:
     - name: "pod_no_exec"
       enabled: True

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -39,6 +39,10 @@ config:
     mutate_empty_dir_size_limit:
       maximum_size_limit: "1Gi"
       default_size_limit: "512Mi"
+    mutate_image_pull_policy:
+      IfNotPresent: 
+        - '^gcr.io/cruise-gcr-prod/daytona.*'
+        - '^gcr.io/cruise-gcr-dev/daytona.*'
   policies:
     - name: "pod_no_exec"
       enabled: True
@@ -83,6 +87,9 @@ config:
       enabled: True
       report_only: False
     - name: "pod_no_shareprocessnamespace"
+      enabled: True
+      report_only: False
+    - name: "pod_image_pull_policy"
       enabled: True
       report_only: False
     - name: "ingress_require_ingress_exemption"

--- a/policies/config.go
+++ b/policies/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	// Defaults to 'runtime/default'
 	PolicyDefaultSeccompPolicy string `json:"policy_default_seccomp_policy"`
 	// PolicyImagePullPolicy contains the images that needs to enforce to a specific ImagePullPolicy
-	PolicyImagePullPolicy   map[string][]string     `json:"policy_image_pull_policy"`
+	PolicyImagePullPolicy   map[string][]string     `json:"mutate_image_pull_policy"`
 	MutateEmptyDirSizeLimit MutateEmptyDirSizeLimit `json:"mutate_empty_dir_size_limit"`
 }
 

--- a/policies/config.go
+++ b/policies/config.go
@@ -30,7 +30,8 @@ type Config struct {
 	// PolicyDefaultSeccompPolicy contains the seccomp policy that you want to be applied on Pods by default.
 	// Defaults to 'runtime/default'
 	PolicyDefaultSeccompPolicy string `json:"policy_default_seccomp_policy"`
-
+	// PolicyImagePullPolicy contains the images that needs to enforce to a specific ImagePullPolicy
+	PolicyImagePullPolicy   map[string][]string     `json:"policy_image_pull_policy"`
 	MutateEmptyDirSizeLimit MutateEmptyDirSizeLimit `json:"mutate_empty_dir_size_limit"`
 }
 

--- a/policies/pod/mutate_image_pull_policy.go
+++ b/policies/pod/mutate_image_pull_policy.go
@@ -1,0 +1,88 @@
+// Copyright 2019 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package ingress
+
+package pod
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	"github.com/cruise-automation/k-rail/policies"
+	"github.com/cruise-automation/k-rail/resource"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PolicyImagePullPolicy is to enforce the imagePullPolicy
+type PolicyImagePullPolicy struct{}
+
+// Name is to return the name of the policy
+func (p PolicyImagePullPolicy) Name() string {
+	return "pod_image_pull_policy"
+}
+
+// Validate is to enforce the imagePullPolicy
+func (p PolicyImagePullPolicy) Validate(ctx context.Context, config policies.Config, ar *admissionv1beta1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
+
+	podResource := resource.GetPodResource(ar, ctx)
+	if podResource == nil {
+		return nil, nil
+	}
+
+	var patches []policies.PatchOperation
+
+	// if there is nothing configured, directly pass the Validate
+	if len(config.PolicyImagePullPolicy) == 0 {
+		return nil, nil
+	}
+
+	if podResource.ResourceKind == "Pod" {
+		for index, container := range podResource.PodSpec.InitContainers {
+			patch := checkImagePullPolicy(&container, fmt.Sprintf("spec/initContainers/%d/imagePullPolicy", index), config.PolicyImagePullPolicy)
+			if patch != nil {
+				patches = append(patches, *patch)
+			}
+		}
+		for index, container := range podResource.PodSpec.Containers {
+			patch := checkImagePullPolicy(&container, fmt.Sprintf("spec/containers/%d/imagePullPolicy", index), config.PolicyImagePullPolicy)
+			if patch != nil {
+				patches = append(patches, *patch)
+			}
+		}
+	}
+
+	return nil, patches
+}
+
+func checkImagePullPolicy(c *corev1.Container, path string, imagePullPolicyMap map[string][]string) *policies.PatchOperation {
+	// loop through pullPolicy enforcement configured
+	for enforcedPullPolicy, imageRegexes := range imagePullPolicyMap {
+		for _, pattern := range imageRegexes {
+			// check if image matches the regex
+			matched, _ := regexp.MatchString(pattern, c.Image)
+			if !matched {
+				continue
+			}
+			if enforcedPullPolicy != string(c.ImagePullPolicy) {
+				return &policies.PatchOperation{
+					Op:    "replace",
+					Path:  path,
+					Value: enforcedPullPolicy,
+				}
+			} else {
+				return nil
+			}
+		}
+	}
+	return nil
+}

--- a/policies/pod/mutate_image_pull_policy.go
+++ b/policies/pod/mutate_image_pull_policy.go
@@ -48,13 +48,13 @@ func (p PolicyImagePullPolicy) Validate(ctx context.Context, config policies.Con
 
 	if podResource.ResourceKind == "Pod" {
 		for index, container := range podResource.PodSpec.InitContainers {
-			patch := checkImagePullPolicy(&container, fmt.Sprintf("spec/initContainers/%d/imagePullPolicy", index), config.PolicyImagePullPolicy)
+			patch := checkImagePullPolicy(&container, fmt.Sprintf("/spec/initContainers/%d/imagePullPolicy", index), config.PolicyImagePullPolicy)
 			if patch != nil {
 				patches = append(patches, *patch)
 			}
 		}
 		for index, container := range podResource.PodSpec.Containers {
-			patch := checkImagePullPolicy(&container, fmt.Sprintf("spec/containers/%d/imagePullPolicy", index), config.PolicyImagePullPolicy)
+			patch := checkImagePullPolicy(&container, fmt.Sprintf("/spec/containers/%d/imagePullPolicy", index), config.PolicyImagePullPolicy)
 			if patch != nil {
 				patches = append(patches, *patch)
 			}

--- a/policies/pod/mutate_image_pull_policy_test.go
+++ b/policies/pod/mutate_image_pull_policy_test.go
@@ -71,9 +71,9 @@ func TestPolicyImagePullPolicy(t *testing.T) {
 				},
 			},
 			expectedPatches: map[string]*policies.PatchOperation{
-				"spec/containers/0/imagePullPolicy": &policies.PatchOperation{
+				"/spec/containers/0/imagePullPolicy": &policies.PatchOperation{
 					Op:    "replace",
-					Path:  "spec/containers/0/imagePullPolicy",
+					Path:  "/spec/containers/0/imagePullPolicy",
 					Value: "IfNotPresent",
 				},
 			},
@@ -104,14 +104,14 @@ func TestPolicyImagePullPolicy(t *testing.T) {
 				},
 			},
 			expectedPatches: map[string]*policies.PatchOperation{
-				"spec/containers/0/imagePullPolicy": &policies.PatchOperation{
+				"/spec/containers/0/imagePullPolicy": &policies.PatchOperation{
 					Op:    "replace",
-					Path:  "spec/containers/0/imagePullPolicy",
+					Path:  "/spec/containers/0/imagePullPolicy",
 					Value: "IfNotPresent",
 				},
-				"spec/initContainers/1/imagePullPolicy": &policies.PatchOperation{
+				"/spec/initContainers/1/imagePullPolicy": &policies.PatchOperation{
 					Op:    "replace",
-					Path:  "spec/initContainers/1/imagePullPolicy",
+					Path:  "/spec/initContainers/1/imagePullPolicy",
 					Value: "IfNotPresent",
 				},
 			},
@@ -142,14 +142,14 @@ func TestPolicyImagePullPolicy(t *testing.T) {
 				},
 			},
 			expectedPatches: map[string]*policies.PatchOperation{
-				"spec/containers/0/imagePullPolicy": &policies.PatchOperation{
+				"/spec/containers/0/imagePullPolicy": &policies.PatchOperation{
 					Op:    "replace",
 					Path:  "spec/containers/0/imagePullPolicy",
 					Value: "Always",
 				},
-				"spec/initContainers/1/imagePullPolicy": &policies.PatchOperation{
+				"/spec/initContainers/1/imagePullPolicy": &policies.PatchOperation{
 					Op:    "replace",
-					Path:  "spec/initContainers/1/imagePullPolicy",
+					Path:  "/spec/initContainers/1/imagePullPolicy",
 					Value: "Always",
 				},
 			},

--- a/policies/pod/mutate_image_pull_policy_test.go
+++ b/policies/pod/mutate_image_pull_policy_test.go
@@ -1,0 +1,184 @@
+// Copyright 2019 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package ingress
+
+package pod
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/cruise-automation/k-rail/policies"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestPolicyImagePullPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		config          policies.Config
+		podSpec         v1.PodSpec
+		expectedPatches map[string]*policies.PatchOperation
+	}{
+		{
+			config: policies.Config{
+				PolicyImagePullPolicy: map[string][]string{
+					"IfNotPresent": []string{"^gcr.io/cruise-gcr-prod/daytona.*", "^gcr.io/cruise-gcr-dev/daytona.*"},
+				},
+			},
+			podSpec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Image:           "gcr.io/cruise-gcr-prod/daytona@sha256:dad671370a148e9dc2442364406",
+						ImagePullPolicy: "Always",
+					},
+				},
+			},
+			expectedPatches: map[string]*policies.PatchOperation{
+				"spec/containers/0/imagePullPolicy": &policies.PatchOperation{
+					Op:    "replace",
+					Path:  "spec/containers/0/imagePullPolicy",
+					Value: "IfNotPresent",
+				},
+			},
+		},
+		{
+			config: policies.Config{
+				PolicyImagePullPolicy: map[string][]string{
+					"IfNotPresent": []string{"^gcr.io/cruise-gcr-prod/daytona.*", "^gcr.io/cruise-gcr-dev/daytona.*"},
+				},
+			},
+			podSpec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Image:           "gcr.io/cruise-gcr-abc/daytona@sha256:dad671370a148e9dc2442364406",
+						ImagePullPolicy: "Always",
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Image:           "gcr.io/cruise-gcr-dev/daytona@sha256:dad671370a148e9dc2442364406",
+						ImagePullPolicy: "IfNotPresent",
+					},
+				},
+			},
+			expectedPatches: nil,
+		},
+		{
+			config: policies.Config{
+				PolicyImagePullPolicy: map[string][]string{
+					"IfNotPresent": []string{"^gcr.io/cruise-gcr-prod/daytona.*", "^gcr.io/cruise-gcr-dev/daytona.*"},
+				},
+			},
+			podSpec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Image:           "gcr.io/cruise-gcr-prod/daytona@sha256:dad671370a148e9dc2442364406",
+						ImagePullPolicy: "Always",
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Image:           "gcr.io/cruise-gcr-dev/daytona@sha256:dad671370a148e9dc2442364406",
+						ImagePullPolicy: "IfNotPresent",
+					},
+					{
+						Image:           "gcr.io/cruise-gcr-dev/daytona@sha256:dad671370a148e9dc2442364406",
+						ImagePullPolicy: "Always",
+					},
+				},
+			},
+			expectedPatches: map[string]*policies.PatchOperation{
+				"spec/containers/0/imagePullPolicy": &policies.PatchOperation{
+					Op:    "replace",
+					Path:  "spec/containers/0/imagePullPolicy",
+					Value: "IfNotPresent",
+				},
+				"spec/initContainers/1/imagePullPolicy": &policies.PatchOperation{
+					Op:    "replace",
+					Path:  "spec/initContainers/1/imagePullPolicy",
+					Value: "IfNotPresent",
+				},
+			},
+		},
+		{
+			config: policies.Config{
+				PolicyImagePullPolicy: map[string][]string{
+					"IfNotPresent": []string{"^gcr.io/cruise-gcr-prod/daytona.*", "^gcr.io/cruise-gcr-dev/daytona.*"},
+					"Always":       []string{"gcr.io/cruise-gcr-prod/abcd"},
+				},
+			},
+			podSpec: v1.PodSpec{
+				Containers: []v1.Container{
+					{
+						Image:           "gcr.io/cruise-gcr-prod/abcd",
+						ImagePullPolicy: "IfNotPresent",
+					},
+				},
+				InitContainers: []v1.Container{
+					{
+						Image:           "gcr.io/cruise-gcr-dev/abcd",
+						ImagePullPolicy: "IfNotPresent",
+					},
+					{
+						Image:           "gcr.io/cruise-gcr-prod/abcd",
+						ImagePullPolicy: "Never",
+					},
+				},
+			},
+			expectedPatches: map[string]*policies.PatchOperation{
+				"spec/containers/0/imagePullPolicy": &policies.PatchOperation{
+					Op:    "replace",
+					Path:  "spec/containers/0/imagePullPolicy",
+					Value: "Always",
+				},
+				"spec/initContainers/1/imagePullPolicy": &policies.PatchOperation{
+					Op:    "replace",
+					Path:  "spec/initContainers/1/imagePullPolicy",
+					Value: "Always",
+				},
+			},
+		},
+	}
+	for index, tt := range tests {
+		t.Run(fmt.Sprintf("Testcase%d", index), func(t *testing.T) {
+
+			raw, _ := json.Marshal(corev1.Pod{Spec: tt.podSpec})
+			ar := &admissionv1beta1.AdmissionRequest{
+				Namespace: "namespace",
+				Name:      "name",
+				Object:    runtime.RawExtension{Raw: raw},
+				Resource:  metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			}
+
+			v := PolicyImagePullPolicy{}
+			_, patches := v.Validate(ctx, tt.config, ar)
+			if len(tt.expectedPatches) != len(patches) {
+				t.Errorf("PolicyImagePullPolicy failed, expected number of Patches:%d, returned number of Patches: %d", len(tt.expectedPatches), len(patches))
+			}
+			for _, patch := range patches {
+				p, ok := tt.expectedPatches[patch.Path]
+				if !ok {
+					t.Errorf("PolicyImagePullPolicy return unwanted patch: %v", patch)
+				}
+				if p.Value != patch.Value || p.Op != patch.Op {
+					t.Errorf("PolicyImagePullPolicy expectedPatch: %v, returned patch: %v", p, patch)
+				}
+			}
+		})
+	}
+}

--- a/server/policies.go
+++ b/server/policies.go
@@ -51,6 +51,7 @@ func (s *Server) registerPolicies() {
 	s.registerPolicy(pod.PolicyMutateSafeToEvict{})
 	s.registerPolicy(pod.PolicyDefaultSeccompPolicy{})
 	s.registerPolicy(pod.PolicyNoShareProcessNamespace{})
+	s.registerPolicy(pod.PolicyImagePullPolicy{})
 	s.registerPolicy(ingress.PolicyRequireIngressExemption{})
 }
 


### PR DESCRIPTION
Adding a mutate image pull policy, which enforce certain images matches in the config to use the specified image pull policy:
1> IfNotPresent:
some base image which is shared by most of the pods across the nodes, by enforcing the imagePullPolicy to IfNotPresent can largely reduce the requests to the Image Repository

2>Always:
some image which require extra access should be protected by ImagePullSecret, hence should not allow anyone to use the cached version in the node.

```yaml
policy_config:
  mutate_image_pull_policy:
    IfNotPresent: 
      - '^gcr.io/cruise-gcr-prod/daytona.*'
      - '^gcr.io/cruise-gcr-dev/daytona.*'
    Always:
      - '^gcr.io/private-repo/secretimage.*'
```