### PR TITLE
Drop Go 1.12.x support in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.13.x]
     runs-on: ubuntu-latest
 
     steps:
@@ -65,7 +65,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.12.x, 1.13.x]
+        go-version: [1.13.x]
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
I don't know if there is any reason to be backwards compatible. There is some practical [issue](https://github.com/cruise-automation/k-rail/pull/54/checks?check_run_id=423126009#step:4:7) with the build flag that I would like to use which was introduced in Go 1.13

> The new go build flag `-trimpath` removes all file system paths from the compiled executable, to improve build reproducibility.

https://golang.org/doc/go1.13#go-command

