### PR TITLE
Updates to webhook configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,24 @@ policy_config:
 
 For the Helm deployment, all configuration is contained in [`deploy/helm/values.yaml`](deploy/helm/values.yaml).
 
+## Webhook Configuration
+
+By default, k-rail will "fail close" if it cannot be reached by the API server. k-rail can be changed to
+"fail open" by changing the `failurePolicy` directive from `Fail` to `Ignore`, in [`deploy/helm/values.yaml`](deploy/helm/values.yaml).
+See the Kubernetes [docs](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy) for
+more details.
+
+In Kubernetes 1.15 and beyond, mutating admission webhooks (e.g. k-rail) can elect to be polled again, if a subsequent admission plugin
+(such as another webhook) modifies an object the webhook has interacted with. 
+They do so with a 
+[`reinvocationPolicy`](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy) 
+value of `IfNeeded`; the Kubernetes default value is `Never`, which does not reinvoke
+the mutating admission webhook(s). 
+Since this is a [newer](https://kubernetes.io/blog/2019/06/19/kubernetes-1-15-release-announcement/) type field, k-rail omits by default,
+but operators can set a chosen value by commenting out `reinvocationPolicy` in [`deploy/helm/values.yaml`](deploy/helm/values.yaml).
+See the [associated KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md#mutating-plugin-ordering) for more details on `reinvocationPolicy` and admission plugin ordering.
+
+
 ## Logging
 
 Log levels can be set in the k-rail configuration file. Acceptable values are `debug`, `warn`, and `info`. The default log level is `info`.

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -52,6 +52,9 @@ webhooks:
           - ingresses
           - pods/exec
     failurePolicy: {{ print .Values.failurePolicy }}
+  {{- if .Values.reinvocationPolicy }}
+    reinvocationPolicy: {{  print .Values.reinvocationPolicy }} 
+  {{- end }}
     sideEffects: None
     namespaceSelector:
       matchExpressions:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -3,6 +3,7 @@ replicaCount: 3
 
 # Set this to 'Fail if you wish that resources apply fail if k-rail is unreachable.
 failurePolicy: Fail
+#reinvocationPolicy: IfNeeded
 
 image:
   repository: cruise/k-rail


### PR DESCRIPTION
Hello!

I added two things to the webhook configuration:

- README context as to the "fail open" vs "fail close" behavior of k-rail, and how to change
this behavior. This **does not** change k-rail's [default behavior](https://github.com/cruise-automation/k-rail/blob/v1.3.1/deploy/helm/values.yaml#L5) of failing closed, just adding some background to
the README so folks are more aware.

- In k8s 1.15+, mutating admission webhooks can specify a `reinvocationPolicy` value in their configuration, which [determines](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#reinvocation-policy) whether or not to re-invoke the plugin (once) if another admission plugin (like another webhook) modifies an object they did, after the fact. Since this won't be supported by all clusters, this PR only adds a `reinvocationPolicy` value to the configuration if users un-comment the associated value in `values.yaml`, which defaults to running the k-rail webhook again if un-commented (`IfNeeded`). On clusters that support `reinvocationPolicy`, but where the k-rail user _has not_ uncommented this value, their webhook will not be run again, since that is the k8s default behavior.

**I tested** the latter point with `helm lint` and `helm template`: if the value is commented out (default), `helm template` emits YAML that does not include the `reinvocationPolicy` directive at all, and `helm template` properly emits YAML that includes `reinvocationPolicy` if it is uncommented in `values.yaml`. This is the desired behavior.

A point on further testing -- the docs and KEP note some expected behavior from the webhook when it is being reinvoked:

> Mutating webhooks can opt-in into at least one re-invocation by specifying reinvocationPolicy: IfNeeded. If a later mutating webhook modifies the object, the earlier webhook will get a second chance.

> This requires that webhooks have an idem-potent-like behaviour which can cope with this second invocation.

https://kubernetes.io/blog/2019/06/19/kubernetes-1-15-release-announcement/

and 

> Mutating plugins that are reinvoked must be idempotent, able to successfully process an object they have already admitted and potentially modified. This will be clearly documented in admission webhook documentation, examples, and test guidelines. Mutating admission webhooks should already support this (since any change they can make in an object could already exist in the user-provided object), and any webhooks that do not are broken for some set of user input.

> Note that idempotence (whether a webhook can successfully operate on its own output) is distinct from the sideEffects indicator, which describes whether a webhook can safely be called in dryRun mode.

https://github.com/kubernetes/enhancements/blob/master/keps/sig-api-machinery/00xx-admission-webhooks-to-ga.md#mutating-plugin-ordering

I believe k-rail meets these constraints, but @dustin-decker **it would be helpful to have your input here** as well.

Thanks!