### PR TITLE
Fix seccomp policy during exec

### DIFF
--- a/policies/pod/bind_mounts.go
+++ b/policies/pod/bind_mounts.go
@@ -30,7 +30,7 @@ func (p PolicyBindMounts) Validate(ctx context.Context, config policies.Config, 
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/docker_sock.go
+++ b/policies/pod/docker_sock.go
@@ -31,7 +31,7 @@ func (p PolicyDockerSock) Validate(ctx context.Context, config policies.Config, 
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/empty_dir_size_limit.go
+++ b/policies/pod/empty_dir_size_limit.go
@@ -33,7 +33,7 @@ const violationText = "Empty dir size limit: size limit exceeds the max value"
 func (p PolicyEmptyDirSizeLimit) Validate(ctx context.Context, config policies.Config, ar *admissionv1beta1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
 	var resourceViolations []policies.ResourceViolation
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/immutable_image_digest.go
+++ b/policies/pod/immutable_image_digest.go
@@ -35,7 +35,7 @@ func (p PolicyImageImmutableReference) Validate(ctx context.Context, config poli
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/mutate_default_seccomp_policy.go
+++ b/policies/pod/mutate_default_seccomp_policy.go
@@ -28,7 +28,7 @@ func (p PolicyDefaultSeccompPolicy) Name() string {
 
 func (p PolicyDefaultSeccompPolicy) Validate(ctx context.Context, config policies.Config, ar *admissionv1beta1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return nil, nil
 	}

--- a/policies/pod/mutate_default_seccomp_policy_test.go
+++ b/policies/pod/mutate_default_seccomp_policy_test.go
@@ -15,6 +15,7 @@ package pod
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/cruise-automation/k-rail/policies"
@@ -41,7 +42,7 @@ func TestPolicyDefaultSeccompPolicy(t *testing.T) {
 			},
 			expectedPatches: map[string]*policies.PatchOperation{
 				"/metadata/annotations/seccomp.security.alpha.kubernetes.io~1pod": &policies.PatchOperation{
-					Op:    "add",
+					Op:    "replace",
 					Path:  "/metadata/annotations/seccomp.security.alpha.kubernetes.io~1pod",
 					Value: "runtime/default",
 				},
@@ -52,10 +53,12 @@ func TestPolicyDefaultSeccompPolicy(t *testing.T) {
 			podSpec:     corev1.PodSpec{},
 			annotations: nil,
 			expectedPatches: map[string]*policies.PatchOperation{
-				"/metadata/annotations/seccomp.security.alpha.kubernetes.io~1pod": &policies.PatchOperation{
-					Op:    "replace",
-					Path:  "/metadata/annotations",
-					Value: "seccomp.security.alpha.kubernetes.io/pod:runtime/default",
+				"/metadata/annotations": &policies.PatchOperation{
+					Op:   "add",
+					Path: "/metadata/annotations",
+					Value: map[string]string{
+						"seccomp.security.alpha.kubernetes.io/pod": "runtime/default",
+					},
 				},
 			},
 		},
@@ -82,7 +85,7 @@ func TestPolicyDefaultSeccompPolicy(t *testing.T) {
 				if !ok {
 					t.Fatalf("PolicyDefaultSeccompPolicy return unwanted patch: %v", patch)
 				}
-				if p.Value != patch.Value || p.Op != patch.Op {
+				if !reflect.DeepEqual(p.Value, patch.Value) || p.Op != patch.Op {
 					t.Fatalf("PolicyDefaultSeccompPolicy expectedPatch: %v, returned patch: %v", p, patch)
 				}
 			}

--- a/policies/pod/mutate_default_seccomp_policy_test.go
+++ b/policies/pod/mutate_default_seccomp_policy_test.go
@@ -1,0 +1,91 @@
+// Copyright 2019 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package ingress
+
+package pod
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cruise-automation/k-rail/policies"
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func TestPolicyDefaultSeccompPolicy(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name            string
+		podSpec         corev1.PodSpec
+		annotations     map[string]string
+		expectedPatches map[string]*policies.PatchOperation
+	}{
+		{
+			name:    "with annotation",
+			podSpec: corev1.PodSpec{},
+			annotations: map[string]string{
+				"cluster-autoscaler.kubernetes.io/safe-to-evict": "true",
+			},
+			expectedPatches: map[string]*policies.PatchOperation{
+				"/metadata/annotations/seccomp.security.alpha.kubernetes.io~1pod": &policies.PatchOperation{
+					Op:    "add",
+					Path:  "/metadata/annotations/seccomp.security.alpha.kubernetes.io~1pod",
+					Value: "runtime/default",
+				},
+			},
+		},
+		{
+			name:        "without annotation",
+			podSpec:     corev1.PodSpec{},
+			annotations: nil,
+			expectedPatches: map[string]*policies.PatchOperation{
+				"/metadata/annotations/seccomp.security.alpha.kubernetes.io~1pod": &policies.PatchOperation{
+					Op:    "replace",
+					Path:  "/metadata/annotations",
+					Value: "seccomp.security.alpha.kubernetes.io/pod:runtime/default",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			raw, _ := json.Marshal(corev1.Pod{Spec: tt.podSpec, ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations}})
+			ar := &admissionv1beta1.AdmissionRequest{
+				Namespace: "namespace",
+				Name:      "name",
+				Object:    runtime.RawExtension{Raw: raw},
+				Resource:  metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"},
+			}
+
+			v := PolicyDefaultSeccompPolicy{}
+			conf := policies.Config{}
+			_, patches := v.Validate(ctx, conf, ar)
+			if len(tt.expectedPatches) != len(patches) {
+				t.Fatalf("PolicyDefaultSeccompPolicy failed, expected number of Patches:%d, returned number of Patches: %d", len(tt.expectedPatches), len(patches))
+			}
+			for _, patch := range patches {
+				p, ok := tt.expectedPatches[patch.Path]
+				if !ok {
+					t.Fatalf("PolicyDefaultSeccompPolicy return unwanted patch: %v", patch)
+				}
+				if p.Value != patch.Value || p.Op != patch.Op {
+					t.Fatalf("PolicyDefaultSeccompPolicy expectedPatch: %v, returned patch: %v", p, patch)
+				}
+			}
+		})
+	}
+}

--- a/policies/pod/mutate_image_pull_policy.go
+++ b/policies/pod/mutate_image_pull_policy.go
@@ -34,7 +34,7 @@ func (p PolicyImagePullPolicy) Name() string {
 // Validate is to enforce the imagePullPolicy
 func (p PolicyImagePullPolicy) Validate(ctx context.Context, config policies.Config, ar *admissionv1beta1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return nil, nil
 	}

--- a/policies/pod/mutate_image_pull_policy_test.go
+++ b/policies/pod/mutate_image_pull_policy_test.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/cruise-automation/k-rail/policies"
@@ -176,7 +177,7 @@ func TestPolicyImagePullPolicy(t *testing.T) {
 				if !ok {
 					t.Fatalf("PolicyImagePullPolicy return unwanted patch: %v", patch)
 				}
-				if p.Value != patch.Value || p.Op != patch.Op {
+				if !reflect.DeepEqual(p.Value, patch.Value) || p.Op != patch.Op {
 					t.Fatalf("PolicyImagePullPolicy expectedPatch: %v, returned patch: %v", p, patch)
 				}
 			}

--- a/policies/pod/mutate_safe_to_evict.go
+++ b/policies/pod/mutate_safe_to_evict.go
@@ -28,7 +28,7 @@ func (p PolicyMutateSafeToEvict) Name() string {
 
 func (p PolicyMutateSafeToEvict) Validate(ctx context.Context, config policies.Config, ar *admissionv1beta1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return nil, nil
 	}

--- a/policies/pod/no_host_network.go
+++ b/policies/pod/no_host_network.go
@@ -31,7 +31,7 @@ func (p PolicyNoHostNetwork) Validate(ctx context.Context, config policies.Confi
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/no_host_pid.go
+++ b/policies/pod/no_host_pid.go
@@ -31,7 +31,7 @@ func (p PolicyNoHostPID) Validate(ctx context.Context, config policies.Config, a
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/no_new_capabilities.go
+++ b/policies/pod/no_new_capabilities.go
@@ -32,7 +32,7 @@ func (p PolicyNoNewCapabilities) Validate(ctx context.Context, config policies.C
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/no_privileged_container.go
+++ b/policies/pod/no_privileged_container.go
@@ -32,7 +32,7 @@ func (p PolicyNoPrivilegedContainer) Validate(ctx context.Context, config polici
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/no_shareprocessnamespace.go
+++ b/policies/pod/no_shareprocessnamespace.go
@@ -31,7 +31,7 @@ func (p PolicyNoShareProcessNamespace) Validate(ctx context.Context, config poli
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/no_tiller.go
+++ b/policies/pod/no_tiller.go
@@ -33,7 +33,7 @@ func (p PolicyNoTiller) Validate(ctx context.Context, config policies.Config, ar
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/safe_to_evict.go
+++ b/policies/pod/safe_to_evict.go
@@ -30,7 +30,7 @@ func (p PolicySafeToEvict) Validate(ctx context.Context, config policies.Config,
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/policies/pod/trusted_repository.go
+++ b/policies/pod/trusted_repository.go
@@ -33,7 +33,7 @@ func (p PolicyTrustedRepository) Validate(ctx context.Context, config policies.C
 
 	resourceViolations := []policies.ResourceViolation{}
 
-	podResource := resource.GetPodResource(ar, ctx)
+	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return resourceViolations, nil
 	}

--- a/resource/pod.go
+++ b/resource/pod.go
@@ -36,7 +36,7 @@ type PodResource struct {
 }
 
 // GetPodResource extracts a PodResource from an AdmissionRequest
-func GetPodResource(ar *admissionv1beta1.AdmissionRequest, ctx context.Context) *PodResource {
+func GetPodResource(ctx context.Context, ar *admissionv1beta1.AdmissionRequest) *PodResource {
 	c := GetResourceCache(ctx)
 	return c.getOrSet(cacheKeyPod, func() interface{} {
 		return decodePodResource(ar)
@@ -44,6 +44,12 @@ func GetPodResource(ar *admissionv1beta1.AdmissionRequest, ctx context.Context) 
 }
 
 func decodePodResource(ar *admissionv1beta1.AdmissionRequest) *PodResource {
+	// omit Pod exec
+	switch ar.Kind {
+	case metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "PodExecOptions"}:
+		return nil
+	}
+
 	switch ar.Resource {
 	case metav1.GroupVersionResource{Group: "", Version: "v1", Resource: "pods"}:
 		pod := corev1.Pod{}

--- a/resource/pod_test.go
+++ b/resource/pod_test.go
@@ -14,7 +14,7 @@ func BenchmarkDecodePodWithoutCaching(b *testing.B) {
 	ctx := context.TODO()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = GetPodResource(req, ctx)
+		_ = GetPodResource(ctx, req)
 	}
 }
 
@@ -23,7 +23,25 @@ func BenchmarkDecodePodCaching(b *testing.B) {
 	ctx := WithResourceCache(context.TODO())
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_ = GetPodResource(req, ctx)
+		_ = GetPodResource(ctx, req)
+	}
+}
+
+func TestWithPodExec(t *testing.T) {
+	req := fakePodExecReq(nil)
+	ctx := WithResourceCache(context.TODO())
+	res := GetPodResource(ctx, req)
+	if res != nil {
+		t.Fatal("should have gotten nil for pod exec request")
+	}
+}
+
+func fakePodExecReq(b []byte) *admissionv1beta1.AdmissionRequest {
+	return &admissionv1beta1.AdmissionRequest{
+		Kind:      metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "PodExecOptions"},
+		Name:      "any",
+		Namespace: "test",
+		Object:    runtime.RawExtension{Raw: b},
 	}
 }
 

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -143,7 +143,7 @@ func (s *Server) validateResources(ar v1beta1.AdmissionReview) v1beta1.Admission
 		// TODO: This could use a bit of refactoring so there is less repetition and we could
 		// have the relevant resource name available for any resource being checked for exemptions.
 		// The AdmissionReview Name is often empty and populated by an downstream controller.
-		podResource := resource.GetPodResource(ar.Request, ctx)
+		podResource := resource.GetPodResource(ctx, ar.Request)
 		if len(violations) == 0 && patches != nil && !policies.IsExempt(
 			podResource.ResourceName,
 			ar.Request.Namespace,


### PR DESCRIPTION
When the Default Seccomp policy (a mutation policy) is enabled, a pod exec will encounter this error:
```
Error from server (InternalError): Internal error occurred: jsonpatch add operation does not apply: doc is missing path: "/metadata/annotations"
```

- Pod resource extraction now ignores execs. This prevents the error encountered during execs when a Pod mutation policy is enabled.
- Adds test for exec request handling for the Pod resource extractor
- Adds test for Default seccomp policy
- Fixes convention of ctx being first arg