### PR TITLE
Add policy to ensure No Persistent Volume HostPath 

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -51,6 +51,7 @@ webhooks:
           - cronjobs
           - ingresses
           - pods/exec
+          - persistentvolumes
     failurePolicy: {{ print .Values.failurePolicy }}
   {{- if .Values.reinvocationPolicy }}
     reinvocationPolicy: {{  print .Values.reinvocationPolicy }} 

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -98,6 +98,9 @@ config:
     - name: "ingress_unique_ingress_host"
       enabled: True
       report_only: False
+    - name: "persistent_volume_no_host_path"
+      enabled: True
+      report_only: False
 
 exemptions:
   - resource_name: "*"

--- a/deploy/non-compliant-persistent-volume.yaml
+++ b/deploy/non-compliant-persistent-volume.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: bad-pv-volume
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 128Mi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "/path/to/data"

--- a/policies/persistentVolume/no_persistent_volume_host.go
+++ b/policies/persistentVolume/no_persistent_volume_host.go
@@ -38,7 +38,7 @@ func (p PolicyNoPersistentVolumeHost) Validate(ctx context.Context, config polic
 
 	violationText := "No Persistent Volume Host Path: Using the host path is forbidden"
 
-	if pvResource.PersistentVolume.Spec.PersistentVolumeSource.HostPath.Path {
+	if pvResource.PersistentVolume.Spec.PersistentVolumeSource.HostPath != nil {
 		resourceViolations = append(resourceViolations, policies.ResourceViolation{
 			Namespace:    ar.Namespace,
 			ResourceName: pvResource.ResourceName,

--- a/policies/persistentVolume/no_persistent_volume_host.go
+++ b/policies/persistentVolume/no_persistent_volume_host.go
@@ -1,0 +1,52 @@
+// Copyright 2019 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.package ingress
+
+package persistentVolume
+
+import (
+	"context"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+
+	"github.com/cruise-automation/k-rail/policies"
+	"github.com/cruise-automation/k-rail/resource"
+)
+
+type PolicyNoPersistentVolumeHost struct{}
+
+func (p PolicyNoPersistentVolumeHost) Name() string {
+	return "persistent_volume_no_host_path"
+}
+
+func (p PolicyNoPersistentVolumeHost) Validate(ctx context.Context, config policies.Config, ar *admissionv1beta1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
+
+	resourceViolations := []policies.ResourceViolation{}
+
+	pvResource := resource.GetPersistentVolumeResource(ctx, ar)
+	if pvResource == nil {
+		return resourceViolations, nil
+	}
+
+	violationText := "No Persistent Volume Host Path: Using the host path is forbidden"
+
+	if pvResource.PersistentVolume.Spec.PersistentVolumeSource.HostPath.Path {
+		resourceViolations = append(resourceViolations, policies.ResourceViolation{
+			Namespace:    ar.Namespace,
+			ResourceName: pvResource.ResourceName,
+			ResourceKind: pvResource.ResourceKind,
+			Violation:    violationText,
+			Policy:       p.Name(),
+		})
+	}
+
+	return resourceViolations, nil
+}

--- a/resource/context.go
+++ b/resource/context.go
@@ -15,6 +15,7 @@ const (
 	cacheKeyPodExec
 	cacheKeyIngress
 	cacheKeyService
+	cacheKeyPersistentVolume
 )
 
 type cache struct {

--- a/resource/persistent_volume.go
+++ b/resource/persistent_volume.go
@@ -37,7 +37,7 @@ func GetPersistentVolumeResource(ctx context.Context, ar *admissionv1beta1.Admis
 
 func decodePersistentVolumeResource(ar *admissionv1beta1.AdmissionRequest) *PersistentVolumeResource {
 	switch ar.Kind {
-	case metav1.GroupVersionKind{Group: "", Version: "v1", Resource: "PersistentVolume"}:
+	case metav1.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolume"}:
 		pv := corev1.PersistentVolume{}
 		if err := decodeObject(ar.Object.Raw, &pv); err != nil {
 			return nil

--- a/resource/persistent_volume.go
+++ b/resource/persistent_volume.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// PersistentVolumeResource contains the information needed for processing by a Policy
+type PersistentVolumeResource struct {
+	PersistentVolume corev1.PersistentVolume
+	ResourceName     string
+	ResourceKind     string
+}
+
+// GetPersistentVolumeResource extracts and PersistentVolumeResource from an AdmissionRequest
+func GetPersistentVolumeResource(ctx context.Context, ar *admissionv1beta1.AdmissionRequest) *PersistentVolumeResource {
+	c := GetResourceCache(ctx)
+	return c.getOrSet(cacheKeyPersistentVolume, func() interface{} {
+		return decodePersistentVolumeResource(ar)
+	}).(*PersistentVolumeResource)
+}
+
+func decodePersistentVolumeResource(ar *admissionv1beta1.AdmissionRequest) *PersistentVolumeResource {
+	switch ar.Resource {
+	case metav1.GroupVersionResource{Group: "core", Version: "v1", Resource: "persistentvolumes"}:
+		pv := corev1.PersistentVolume{}
+		if err := decodeObject(ar.Object.Raw, &pv); err != nil {
+			return nil
+		}
+		return &PersistentVolumeResource{
+			PersistentVolume: pv,
+			ResourceName:     GetResourceName(pv.ObjectMeta),
+			ResourceKind:     "PersistentVolume",
+		}
+	default:
+		return nil
+	}
+}

--- a/resource/persistent_volume.go
+++ b/resource/persistent_volume.go
@@ -36,8 +36,8 @@ func GetPersistentVolumeResource(ctx context.Context, ar *admissionv1beta1.Admis
 }
 
 func decodePersistentVolumeResource(ar *admissionv1beta1.AdmissionRequest) *PersistentVolumeResource {
-	switch ar.Resource {
-	case metav1.GroupVersionResource{Group: "core", Version: "v1", Resource: "persistentvolumes"}:
+	switch ar.Kind {
+	case metav1.GroupVersionKind{Group: "", Version: "v1", Resource: "PersistentVolume"}:
 		pv := corev1.PersistentVolume{}
 		if err := decodeObject(ar.Object.Raw, &pv); err != nil {
 			return nil

--- a/server/policies.go
+++ b/server/policies.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cruise-automation/k-rail/policies"
 	"github.com/cruise-automation/k-rail/policies/ingress"
+	"github.com/cruise-automation/k-rail/policies/persistentVolume"
 	"github.com/cruise-automation/k-rail/policies/pod"
 	"github.com/cruise-automation/k-rail/policies/service"
 	log "github.com/sirupsen/logrus"
@@ -55,6 +56,7 @@ func (s *Server) registerPolicies() {
 	s.registerPolicy(pod.PolicyImagePullPolicy{})
 	s.registerPolicy(ingress.PolicyRequireIngressExemption{})
 	s.registerPolicy(service.PolicyRequireServiceLoadbalancerExemption{})
+	s.registerPolicy(persistentVolume.PolicyNoPersistentVolumeHost{})
 	requireUniqueHostPolicy, err := ingress.NewPolicyRequireUniqueHost()
 	if err != nil {
 		log.WithError(err).Error("could not load RequireUniqueHostPolicy")


### PR DESCRIPTION
This PR adds a k-rail policy to ensure that Persistent Volumes cannot specify a Host Path. Enforcing the policy prevents direct access to potentially sensitive files or directories on the Node-level. As [Kubernetes documentation](https://kubernetes.io/docs/tasks/configure-pod-container/configure-persistent-volume-storage/#create-a-persistentvolume) suggests, production clusters should not use HostPath. Instead a cluster administrator would provision a network resource like a Google Compute Engine persistent disk, an NFS share, or an Amazon Elastic Block Store volume. 

This PR also adds a Persistent Volume resource so that k-rail can identify and extract the resource from an AdmissionRequest.