### PR TITLE
Fix bug in helm chart when namespace != k-rail

### DIFF
--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: k-rail
-version: 0.1.0
+version: 0.1.1

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -32,15 +32,15 @@ webhooks:
   - name: k-rail.cruise-automation.github.com
     clientConfig:
       service:
-        namespace: k-rail
-        name: {{ .Release.Namespace }}
+        namespace: {{ .Release.Namespace }}
+        name: k-rail
         path: "/"
       caBundle: {{ b64enc $ca.Cert }}
     rules:
       - operations: ["CREATE","UPDATE","CONNECT"]
         apiGroups: ["*"]
         apiVersions: ["*"]
-        resources: 
+        resources:
           - pods
           - deployments
           - replicationcontrollers
@@ -54,14 +54,14 @@ webhooks:
           - persistentvolumes
     failurePolicy: {{ print .Values.failurePolicy }}
   {{- if .Values.reinvocationPolicy }}
-    reinvocationPolicy: {{  print .Values.reinvocationPolicy }} 
+    reinvocationPolicy: {{  print .Values.reinvocationPolicy }}
   {{- end }}
     sideEffects: None
     namespaceSelector:
       matchExpressions:
         - key: name
           operator: NotIn
-          values: 
+          values:
             - {{ .Release.Namespace }}
 ---
 apiVersion: apps/v1
@@ -80,7 +80,7 @@ spec:
     metadata:
       name: k-rail
       labels:
-        name: k-rail 
+        name: k-rail
       annotations:
         checksum/config: {{ print .Values.config | sha256sum }}
         checksum/exemptions: {{ print .Values.exemptions | sha256sum }}
@@ -218,4 +218,4 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: k-rail
-  namespace: {{ .Release.Namespace }} 
+  namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The helm chart didn't produce a working admission webhook when installing in a namespace other than `k-rail`

This was because the service name and namespace name are transposed in the webhook configuration.

This PR corrects that.

Thanks!
Andy