### PR TITLE
Add customizable timeout

### DIFF
--- a/charts/k-rail/Chart.yaml
+++ b/charts/k-rail/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 name: k-rail
 description: Kubernetes security tool for policy enforcement
 home: https://github.com/cruise-automation/k-rail
-version: v2.3.1
+version: v2.3.2

--- a/charts/k-rail/templates/deployment.yaml
+++ b/charts/k-rail/templates/deployment.yaml
@@ -54,7 +54,7 @@ webhooks:
     reinvocationPolicy: {{  print .Values.reinvocationPolicy }}
   {{- end }}
     sideEffects: None
-    timeoutSeconds: 1  # doesn't do anything until 1.14
+    timeoutSeconds: {{ .Values.webhookTimeout }}
     namespaceSelector:
       matchExpressions:
         - key: k-rail/ignore

--- a/charts/k-rail/values.yaml
+++ b/charts/k-rail/values.yaml
@@ -24,6 +24,10 @@ tolerations: []
 
 affinity: {}
 
+# Set to the value (in seconds) which the mutatingwebhook should use for a timeout
+# for slower clusters (or larger workloads) this may need to be increased
+webhookTimeout: 1
+
 config:
   cluster_name: default
   log_level: info


### PR DESCRIPTION
Hey dudes!

The default webhook timeout of 1s is causing grief for us sometimes, especially when we apply large amounts of manifests at the same time, using `kubectl apply -f <path to directory>`. This change simply adds the option to increase the timeout (which has anecdotally helped in our case), while leaving the default at 1s.

Here's an example of the problem I'm trying to solve:

```
history.go:53: [debug] getting history for release harbor
install.go:172: [debug] Original chart version: "8.0.0"
install.go:189: [debug] CHART PATH: /root/.cache/helm/repository/harbor-8.0.0.tgz
client.go:108: [debug] creating 46 resource(s)
Error: Internal error occurred: failed calling webhook "k-rail.cruise-automation.github.com": Post https://k-rail.k-rail.svc:443/?timeout=1s: context deadline exceeded
helm.go:94: [debug] Internal error occurred: failed calling webhook "k-rail.cruise-automation.github.com": Post https://k-rail.k-rail.svc:443/?timeout=1s: context deadline exceeded
```
