### PR TITLE
Release v3.1.0 of the chart

### DIFF
--- a/charts/k-rail/Chart.yaml
+++ b/charts/k-rail/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 name: k-rail
 description: Kubernetes security tool for policy enforcement
 home: https://github.com/cruise-automation/k-rail
-version: v3.0.0
+version: v3.1.0


### PR DESCRIPTION
This should be done when a release is tagged. It's easy to forget, maybe there's a better way to do this?