### PR TITLE
policy executions with labels in prom metrics

### DIFF
--- a/server/config.go
+++ b/server/config.go
@@ -30,7 +30,8 @@ type Config struct {
 		Cert string
 		Key  string
 	}
-	GlobalReportOnly bool `json:"global_report_only"`
+	GlobalReportOnly     bool `json:"global_report_only"`
+	GlobalMetricsEnabled bool `json:"global_metrics_enabled"`
 	Policies         []PolicySettings
 	PolicyConfig     policies.Config        `json:"policy_config"`
 	PluginConfig     map[string]interface{} `json:"plugin_config"`

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -13,6 +13,7 @@
 package server
 
 import (
+	"github.com/prometheus/client_golang/prometheus"
 	metrics "github.com/slok/go-http-metrics/metrics/prometheus"
 	"github.com/slok/go-http-metrics/middleware"
 )
@@ -20,3 +21,28 @@ import (
 var prometheusMiddleware = middleware.New(middleware.Config{
 	Recorder: metrics.NewRecorder(metrics.Config{}),
 })
+
+var totalRegisteredPolicies = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: "krail",
+		Name:      "total_registered_policies",
+		Help:      "Total Policies Registered",
+	},
+)
+
+var totalLoadedPlugins = prometheus.NewCounter(
+	prometheus.CounterOpts{
+		Namespace: "krail",
+		Name:      "total_loaded_plugins",
+		Help:      "Total Plugins Loaded",
+	},
+)
+
+var policyViolations = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "krail",
+		Name:      "policy_violations",
+		Help:      "Count of Violations",
+	},
+	[]string{"kind", "resource", "namespace", "policy", "user", "enforced", "exempt", "report_only", "global_report_only"},
+)

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -44,5 +44,5 @@ var policyViolations = prometheus.NewCounterVec(
 		Name:      "policy_violations",
 		Help:      "Count of Violations",
 	},
-	[]string{"kind", "resource", "namespace", "policy", "user", "enforced", "exempt", "report_only", "global_report_only"},
+	[]string{"resource", "namespace", "policy", "enforced"},
 )

--- a/server/policies.go
+++ b/server/policies.go
@@ -28,8 +28,6 @@ import (
 	"github.com/cruise-automation/k-rail/v3/policies/poddisruptionbudget"
 	rolebinding "github.com/cruise-automation/k-rail/v3/policies/rolebinding"
 	"github.com/cruise-automation/k-rail/v3/policies/service"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Policy specifies how a Policy is implemented
@@ -43,8 +41,6 @@ type Policy interface {
 }
 
 func (s *Server) registerPolicies() {
-	prometheus.MustRegister(totalRegisteredPolicies)
-
 	// Policies will be run in the order that they are registered.
 	// Policies that mutate will have their resulting patch merged with any previous patches in that order as well.
 

--- a/server/policies.go
+++ b/server/policies.go
@@ -28,6 +28,8 @@ import (
 	"github.com/cruise-automation/k-rail/v3/policies/poddisruptionbudget"
 	rolebinding "github.com/cruise-automation/k-rail/v3/policies/rolebinding"
 	"github.com/cruise-automation/k-rail/v3/policies/service"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 // Policy specifies how a Policy is implemented
@@ -41,6 +43,8 @@ type Policy interface {
 }
 
 func (s *Server) registerPolicies() {
+	prometheus.MustRegister(totalRegisteredPolicies)
+
 	// Policies will be run in the order that they are registered.
 	// Policies that mutate will have their resulting patch merged with any previous patches in that order as well.
 
@@ -99,6 +103,8 @@ func (s *Server) registerPolicy(v Policy) {
 		if val.Name == v.Name() {
 			found = true
 			if val.Enabled {
+				totalRegisteredPolicies.Inc()
+
 				if s.Config.GlobalReportOnly {
 					s.ReportOnlyPolicies = append(s.ReportOnlyPolicies, v)
 					log.Infof("enabling %s validator in REPORT ONLY mode because GLOBAL REPORT ONLY MODE is on", v.Name())

--- a/server/server.go
+++ b/server/server.go
@@ -87,6 +87,7 @@ func Run(ctx context.Context) {
 		log.Infof("loaded %d exemptions", len(exemptions))
 	}
 
+	prometheus.MustRegister(totalRegisteredPolicies)
 	prometheus.MustRegister(policyViolations)
 	prometheus.MustRegister(totalLoadedPlugins)
 

--- a/server/server.go
+++ b/server/server.go
@@ -28,6 +28,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/yaml"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/slok/go-http-metrics/middleware/std"
 )
@@ -86,6 +87,9 @@ func Run(ctx context.Context) {
 		log.Infof("loaded %d exemptions", len(exemptions))
 	}
 
+	prometheus.MustRegister(policyViolations)
+	prometheus.MustRegister(totalLoadedPlugins)
+
 	var loadedPlugins []plugins.Plugin
 	if *pluginsPathGlob != "" {
 		loadedPlugins, err = plugins.PluginsFromDirectory(*pluginsPathGlob)
@@ -107,6 +111,8 @@ func Run(ctx context.Context) {
 			} else {
 				log.Infof("no plugin config found for plugin %s, continuing on", plugin.Name())
 			}
+
+			totalLoadedPlugins.Add(1)
 		}
 
 		log.Infof("loaded %d plugins", len(loadedPlugins))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -44,5 +44,6 @@ func testPrometheusMetrics(t *testing.T, h http.Handler, expMetrics []string) {
 	assert.Contains(metrics, "go_")
 	assert.Contains(metrics, "go_gc_")
 	assert.Contains(metrics, "http_")
+	assert.Contains(metrics, "krail_")
 	assert.Contains(metrics, "promhttp_metric_handler")
 }

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -205,17 +205,14 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 			"enforced":  false,
 		}).Info("EXEMPT")
 
-		labels := prometheus.Labels{
-			"kind":               v.ResourceKind,
-			"resource":           v.ResourceName,
-			"namespace":          v.Namespace,
-			"policy":             v.Policy,
-			"user":               ar.Request.UserInfo.Username,
-			"enforced":           "false",
-			"exempt":             "true",
-			"report_only":        "false",
-			"global_report_only": fmt.Sprintf("%v", s.Config.GlobalReportOnly)}
-		policyViolations.With(labels).Inc()
+		if s.Config.GlobalMetricsEnabled == true {
+			labels := prometheus.Labels{
+				"resource":           v.ResourceName,
+				"namespace":          v.Namespace,
+				"policy":             v.Policy,
+				"enforced":  		  "false"}
+			policyViolations.With(labels).Inc()
+		}
 	}
 
 	// log report-only violations
@@ -229,17 +226,14 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 			"enforced":  false,
 		}).Info("NOT ENFORCED")
 
-		labels := prometheus.Labels{
-			"kind":               v.ResourceKind,
-			"resource":           v.ResourceName,
-			"namespace":          v.Namespace,
-			"policy":             v.Policy,
-			"user":               ar.Request.UserInfo.Username,
-			"enforced":           "false",
-			"exempt":             "false",
-			"report_only":        "true",
-			"global_report_only": fmt.Sprintf("%v", s.Config.GlobalReportOnly)}
-		policyViolations.With(labels).Inc()
+		if s.Config.GlobalMetricsEnabled == true {
+			labels := prometheus.Labels{
+				"resource":           v.ResourceName,
+				"namespace":          v.Namespace,
+				"policy":             v.Policy,
+				"enforced":  		  "false"}
+			policyViolations.With(labels).Inc()
+		}
 	}
 
 	// log enforced violations when in global report-only mode
@@ -254,17 +248,14 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 				"enforced":  false,
 			}).Info("NOT ENFORCED")
 
-			labels := prometheus.Labels{
-				"kind":               v.ResourceKind,
-				"resource":           v.ResourceName,
-				"namespace":          v.Namespace,
-				"policy":             v.Policy,
-				"user":               ar.Request.UserInfo.Username,
-				"enforced":           "false",
-				"exempt":             "false",
-				"report_only":        "true",
-				"global_report_only": fmt.Sprintf("%v", s.Config.GlobalReportOnly)}
-			policyViolations.With(labels).Inc()
+			if s.Config.GlobalMetricsEnabled == true {
+				labels := prometheus.Labels{
+					"resource":           v.ResourceName,
+					"namespace":          v.Namespace,
+					"policy":             v.Policy,
+					"enforced":  		  "false"}
+				policyViolations.With(labels).Inc()
+			}
 		}
 	}
 
@@ -281,17 +272,14 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 				"enforced":  true,
 			}).Warn("ENFORCED")
 
-			labels := prometheus.Labels{
-				"kind":               v.ResourceKind,
-				"resource":           v.ResourceName,
-				"namespace":          v.Namespace,
-				"policy":             v.Policy,
-				"user":               ar.Request.UserInfo.Username,
-				"enforced":           "true",
-				"exempt":             "false",
-				"report_only":        "false",
-				"global_report_only": fmt.Sprintf("%v", s.Config.GlobalReportOnly)}
-			policyViolations.With(labels).Inc()
+			if s.Config.GlobalMetricsEnabled == true {
+				labels := prometheus.Labels{
+					"resource":           v.ResourceName,
+					"namespace":          v.Namespace,
+					"policy":             v.Policy,
+					"enforced":  		  "true"}
+				policyViolations.With(labels).Inc()
+			}
 
 			violations = violations + "\n" + v.HumanString()
 		}

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -30,6 +30,8 @@ import (
 
 	"github.com/cruise-automation/k-rail/v3/policies"
 	"github.com/cruise-automation/k-rail/v3/resource"
+
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var (
@@ -202,6 +204,18 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 			"user":      ar.Request.UserInfo.Username,
 			"enforced":  false,
 		}).Info("EXEMPT")
+
+		labels := prometheus.Labels{
+			"kind":               v.ResourceKind,
+			"resource":           v.ResourceName,
+			"namespace":          v.Namespace,
+			"policy":             v.Policy,
+			"user":               ar.Request.UserInfo.Username,
+			"enforced":           "false",
+			"exempt":             "true",
+			"report_only":        "false",
+			"global_report_only": fmt.Sprintf("%v", s.Config.GlobalReportOnly)}
+		policyViolations.With(labels).Inc()
 	}
 
 	// log report-only violations
@@ -214,6 +228,18 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 			"user":      ar.Request.UserInfo.Username,
 			"enforced":  false,
 		}).Info("NOT ENFORCED")
+
+		labels := prometheus.Labels{
+			"kind":               v.ResourceKind,
+			"resource":           v.ResourceName,
+			"namespace":          v.Namespace,
+			"policy":             v.Policy,
+			"user":               ar.Request.UserInfo.Username,
+			"enforced":           "false",
+			"exempt":             "false",
+			"report_only":        "true",
+			"global_report_only": fmt.Sprintf("%v", s.Config.GlobalReportOnly)}
+		policyViolations.With(labels).Inc()
 	}
 
 	// log enforced violations when in global report-only mode
@@ -227,6 +253,18 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 				"user":      ar.Request.UserInfo.Username,
 				"enforced":  false,
 			}).Info("NOT ENFORCED")
+
+			labels := prometheus.Labels{
+				"kind":               v.ResourceKind,
+				"resource":           v.ResourceName,
+				"namespace":          v.Namespace,
+				"policy":             v.Policy,
+				"user":               ar.Request.UserInfo.Username,
+				"enforced":           "false",
+				"exempt":             "false",
+				"report_only":        "true",
+				"global_report_only": fmt.Sprintf("%v", s.Config.GlobalReportOnly)}
+			policyViolations.With(labels).Inc()
 		}
 	}
 
@@ -242,6 +280,19 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 				"user":      ar.Request.UserInfo.Username,
 				"enforced":  true,
 			}).Warn("ENFORCED")
+
+			labels := prometheus.Labels{
+				"kind":               v.ResourceKind,
+				"resource":           v.ResourceName,
+				"namespace":          v.Namespace,
+				"policy":             v.Policy,
+				"user":               ar.Request.UserInfo.Username,
+				"enforced":           "true",
+				"exempt":             "false",
+				"report_only":        "false",
+				"global_report_only": fmt.Sprintf("%v", s.Config.GlobalReportOnly)}
+			policyViolations.With(labels).Inc()
+
 			violations = violations + "\n" + v.HumanString()
 		}
 


### PR DESCRIPTION
Adding policy execution metrics, loaded plugins and registered policies

Example of each in `/metrics` output

```
krail_policy_violations{enforced="true",exempt="false",global_report_only="false",kind="PodExec",namespace="ecommerce",policy="pod_no_exec",report_only="false",resource="payment-processor",user="bob@amyshardware.com"} 1
krail_policy_violations{enforced="false",exempt="false",global_report_only="false",kind="PodExec",namespace="sandbox",policy="pod_no_exec",report_only="true",resource="payment-processor",user="bob@amyshardware.com"} 8
krail_total_loaded_plugins 0
krail_total_registered_policies 23
```