### PR TITLE
Add disallow nginx snippet policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,10 @@ Prevents users from specifing an unconfined apparmor policy which can be used wi
 
 When a Custom Resource Definition is deleted the corresponding Custom Resources are deleted as well. This creates the risk of accidentally destroying important data during regular maintenance. This policy allows the user to set the annotation `k-rail.crd.protect: enabled` on any CRD which will prevent its deletion if any children CRs exist.
 
+## Disallow NGINX Snippet
+
+In response to [NGINX Ingress Controller vulnerability CVE-2021-25742](https://github.com/kubernetes/ingress-nginx/issues/7837), this rule will disallow usages of all NGINX snippet annotations.
+
 # Configuration
 
 For the Helm deployment, all configuration is contained in [`charts/k-rail/values.yaml`](charts/k-rail/values.yaml).

--- a/policies/ingress/disallow_nginx_snippet.go
+++ b/policies/ingress/disallow_nginx_snippet.go
@@ -1,0 +1,58 @@
+// Copyright 2021 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+
+	admissionv1 "k8s.io/api/admission/v1"
+
+	"github.com/cruise-automation/k-rail/v3/policies"
+	"github.com/cruise-automation/k-rail/v3/resource"
+)
+
+var nginxSnippetAnnotationRegex = regexp.MustCompile("^nginx.ingress.kubernetes.io/.*-snippet$")
+
+type PolicyDisallowNGINXSnippet struct{}
+
+func (p PolicyDisallowNGINXSnippet) Name() string {
+	return "ingress_disallow_nginx_snippet"
+}
+
+func (p PolicyDisallowNGINXSnippet) Validate(ctx context.Context, config policies.Config, ar *admissionv1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
+
+	resourceViolations := []policies.ResourceViolation{}
+
+	ingressResource := resource.GetIngressResource(ctx, ar)
+	if ingressResource == nil {
+		return resourceViolations, nil
+	}
+
+	if ingressResource.IngressExt.Annotations == nil {
+		return resourceViolations, nil
+	}
+	for key := range ingressResource.IngressExt.Annotations {
+		if nginxSnippetAnnotationRegex.MatchString(key) {
+			resourceViolations = append(resourceViolations, policies.ResourceViolation{
+				Namespace:    ar.Namespace,
+				ResourceName: ingressResource.ResourceName,
+				ResourceKind: ingressResource.ResourceKind,
+				Violation:    fmt.Sprintf("NGINX Snippets are not allowed, found %q", key),
+				Policy:       p.Name(),
+			})
+		}
+	}
+	return resourceViolations, nil
+}

--- a/policies/ingress/disallow_nginx_snippet_test.go
+++ b/policies/ingress/disallow_nginx_snippet_test.go
@@ -1,0 +1,92 @@
+// Copyright 2021 Cruise LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//    https://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ingress
+
+import (
+	"context"
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	admissionv1 "k8s.io/api/admission/v1"
+	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/cruise-automation/k-rail/v3/policies"
+)
+
+func TestPolicyDisallowNGINXSnippet(t *testing.T) {
+	ctx := context.Background()
+
+	tests := []struct {
+		name       string
+		ingressExt *extensionsv1beta1.Ingress
+		violations int
+	}{
+		{
+			name:       "deny 1",
+			violations: 1,
+			ingressExt: &extensionsv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"nginx.ingress.kubernetes.io/server-snippet": "i'm malicious",
+					},
+				},
+			},
+		},
+		{
+			name:       "deny 2",
+			violations: 2,
+			ingressExt: &extensionsv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"nginx.ingress.kubernetes.io/server-snippet": "i'm malicious",
+						"nginx.ingress.kubernetes.io/auth-snippet":   "me too",
+					},
+				},
+			},
+		},
+		{
+			name:       "allow",
+			violations: 0,
+			ingressExt: &extensionsv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ar = &admissionv1.AdmissionRequest{}
+
+			if tt.ingressExt != nil {
+				raw, _ := json.Marshal(tt.ingressExt)
+				ar = &admissionv1.AdmissionRequest{
+					Namespace: "namespace",
+					Name:      "name",
+					Object:    runtime.RawExtension{Raw: raw},
+					Resource:  metav1.GroupVersionResource{Group: "extensions", Version: "v1beta1", Resource: "ingresses"},
+				}
+			}
+
+			v := PolicyDisallowNGINXSnippet{}
+			if got, _ := v.Validate(ctx, policies.Config{}, ar); !reflect.DeepEqual(len(got), tt.violations) {
+				t.Errorf("PolicyDisallowNGINXSnippet() %s got %v want %v violations", tt.name, len(got), tt.violations)
+			}
+		})
+	}
+}

--- a/server/policies.go
+++ b/server/policies.go
@@ -70,6 +70,7 @@ func (s *Server) registerPolicies() {
 	s.registerPolicy(persistentvolume.PolicyNoPersistentVolumeHost{})
 	s.registerPolicy(clusterrolebinding.PolicyNoAnonymousClusterRoleBinding{})
 	s.registerPolicy(rolebinding.PolicyNoAnonymousRoleBinding{})
+	s.registerPolicy(ingress.PolicyDisallowNGINXSnippet{})
 	requireUniqueHostPolicy, err := ingress.NewPolicyRequireUniqueHost()
 	if err != nil {
 		log.WithError(err).Error("could not load RequireUniqueHostPolicy")


### PR DESCRIPTION
This adds a policy to disallow usages of all NGINX snippet annotations, in response to [NGINX Ingress Controller vulnerability CVE-2021-25742](https://github.com/kubernetes/ingress-nginx/issues/7837)