### PR TITLE
Stopped collection of mutations on DELETE operations

### DIFF
--- a/policies/pod/mutate_default_seccomp_policy.go
+++ b/policies/pod/mutate_default_seccomp_policy.go
@@ -28,6 +28,10 @@ func (p PolicyDefaultSeccompPolicy) Name() string {
 
 func (p PolicyDefaultSeccompPolicy) Validate(ctx context.Context, config policies.Config, ar *admissionv1.AdmissionRequest) ([]policies.ResourceViolation, []policies.PatchOperation) {
 
+	if ar.Operation == "DELETE" {
+		return nil, nil
+	}
+
 	podResource := resource.GetPodResource(ctx, ar)
 	if podResource == nil {
 		return nil, nil

--- a/server/webhook.go
+++ b/server/webhook.go
@@ -152,7 +152,10 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 			val.Name(),
 			s.Exemptions,
 		) {
-			mutationPatches = append(mutationPatches, patches...)
+			// K8s will not allow the mutation of DELETE operations
+			if ar.Request.Operation != "DELETE" {
+				mutationPatches = append(mutationPatches, patches...)
+			}
 		}
 
 		// apply exempt and non-exempt violations
@@ -207,10 +210,10 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 
 		if s.Config.GlobalMetricsEnabled == true {
 			labels := prometheus.Labels{
-				"resource":           v.ResourceName,
-				"namespace":          v.Namespace,
-				"policy":             v.Policy,
-				"enforced":  		  "false"}
+				"resource":  v.ResourceName,
+				"namespace": v.Namespace,
+				"policy":    v.Policy,
+				"enforced":  "false"}
 			policyViolations.With(labels).Inc()
 		}
 	}
@@ -228,10 +231,10 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 
 		if s.Config.GlobalMetricsEnabled == true {
 			labels := prometheus.Labels{
-				"resource":           v.ResourceName,
-				"namespace":          v.Namespace,
-				"policy":             v.Policy,
-				"enforced":  		  "false"}
+				"resource":  v.ResourceName,
+				"namespace": v.Namespace,
+				"policy":    v.Policy,
+				"enforced":  "false"}
 			policyViolations.With(labels).Inc()
 		}
 	}
@@ -250,10 +253,10 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 
 			if s.Config.GlobalMetricsEnabled == true {
 				labels := prometheus.Labels{
-					"resource":           v.ResourceName,
-					"namespace":          v.Namespace,
-					"policy":             v.Policy,
-					"enforced":  		  "false"}
+					"resource":  v.ResourceName,
+					"namespace": v.Namespace,
+					"policy":    v.Policy,
+					"enforced":  "false"}
 				policyViolations.With(labels).Inc()
 			}
 		}
@@ -274,10 +277,10 @@ func (s *Server) validateResources(ar admissionv1.AdmissionReview) admissionv1.A
 
 			if s.Config.GlobalMetricsEnabled == true {
 				labels := prometheus.Labels{
-					"resource":           v.ResourceName,
-					"namespace":          v.Namespace,
-					"policy":             v.Policy,
-					"enforced":  		  "true"}
+					"resource":  v.ResourceName,
+					"namespace": v.Namespace,
+					"policy":    v.Policy,
+					"enforced":  "true"}
 				policyViolations.With(labels).Inc()
 			}
 


### PR DESCRIPTION
The Default Seccomp policy was mutating DELETE operations, which the k8s API does not accept.
This was preventing the normal deletion of pods as long as this policy was enabled.

By adding an early return to the policy which avoids the processing of DELETE requests, #122 should be resolved.