### PR TITLE
Fix example plugin bug

### DIFF
--- a/plugins/examples/example.go
+++ b/plugins/examples/example.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 	"math/rand"
@@ -95,6 +96,7 @@ func (t ThresholdPolicy) Validate(ctx context.Context,
 			ResourceKind: podResource.ResourceKind,
 			Violation:    violationText,
 			Policy:       t.Name(),
+			Error:        errors.New(violationText),
 		})
 
 	}


### PR DESCRIPTION
Example plugin is called from here (https://github.com/cruise-automation/k-rail/blob/master/plugins/grpc.go#L104-L119)  and attributes of the returned value are used, but `voiolation.Error` is `nil` so `violation.Error.Error()` is nil reference.

After making webhook and send request by `kubectl apply -f pod.yaml`, the above bug causes following error

<details>
<summary>error log</summary>

```bash
$ make run-plugin
(...snip)
{"level":"warning","msg":"configuration not present for ingress_require_ingress_exemption validator, enabling REPORT ONLY mode","time":"2021-12-04T02:00:58Z"}
{"level":"warning","msg":"configuration not present for service_require_loadbalancer_exemption validator, enabling REPORT ONLY mode","time":"2021-12-04T02:00:58Z"}
{"level":"warning","msg":"configuration not present for service_require_virtualservice_gateway_exemption validator, enabling REPORT ONLY mode","time":"2021-12-04T02:00:58Z"}
{"level":"warning","msg":"configuration not present for service_no_external_ip validator, enabling REPORT ONLY mode","time":"2021-12-04T02:00:58Z"}
{"level":"warning","msg":"configuration not present for persistent_volume_no_host_path validator, enabling REPORT ONLY mode","time":"2021-12-04T02:00:58Z"}
{"level":"warning","msg":"configuration not present for cluster_role_binding_no_anonymous_subject validator, enabling REPORT ONLY mode","time":"2021-12-04T02:00:58Z"}
{"level":"warning","msg":"configuration not present for role_binding_no_anonymous_subject validator, enabling REPORT ONLY mode","time":"2021-12-04T02:00:58Z"}
{"level":"warning","msg":"configuration not present for ingress_disallow_nginx_snippet validator, enabling REPORT ONLY mode","time":"2021-12-04T02:00:58Z"}
{"error":"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined","level":"error","msg":"could not load RequireUniqueHostPolicy","time":"2021-12-04T02:00:58Z"}
{"error":"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined","level":"error","msg":"could not load InvalidPodDisruptionBudget policy","time":"2021-12-04T02:00:58Z"}
{"error":"unable to load in-cluster configuration, KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT must be defined","level":"error","msg":"could not load CRDProtect policy","
time":"2021-12-04T02:00:58Z"}
{"level":"info","msg":"enabling luck_threshold validator in ENFORCE mode","time":"2021-12-04T02:00:58Z"}
{"level":"info","msg":"metrics listening at :2112","time":"2021-12-04T02:00:58Z"}
2021-12-04T02:01:05.728Z [DEBUG] plugin.plugin: panic: runtime error: invalid memory address or nil pointer dereference
2021-12-04T02:01:05.728Z [DEBUG] plugin.plugin: [signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0xa4fb88]
2021-12-04T02:01:05.728Z [DEBUG] plugin.plugin:
2021-12-04T02:01:05.729Z [DEBUG] plugin.plugin: goroutine 37 [running]:
2021-12-04T02:01:05.729Z [DEBUG] plugin.plugin: github.com/cruise-automation/k-rail/v3/plugins.(*GRPCServer).Validate(0xc000234bf0, {0xc0000a0550, 0x489f46}, 0xc0000a0550)
2021-12-04T02:01:05.729Z [DEBUG] plugin.plugin:         /home/ubuntu/k-rail/plugins/grpc.go:117 +0x448
2021-12-04T02:01:05.729Z [DEBUG] plugin.plugin: github.com/cruise-automation/k-rail/v3/plugins/proto._KRailPlugin_Validate_Handler({0xfc61c0, 0xc000234bf0}, {0x1255260, 0xc0000b2
db0}, 0xc00009c900, 0x0)
2021-12-04T02:01:05.729Z [DEBUG] plugin.plugin:         /home/ubuntu/k-rail/plugins/proto/plugin.pb.go:968 +0x170
2021-12-04T02:01:05.729Z [DEBUG] plugin.plugin: google.golang.org/grpc.(*Server).processUnaryRPC(0xc000201880, {0x1271430, 0xc00015cc00}, 0xc0000ba500, 0xc0002a19e0, 0x1a67388, 0
x0)
2021-12-04T02:01:05.729Z [DEBUG] plugin.plugin:         /home/ubuntu/go/pkg/mod/google.golang.org/grpc@v1.35.0/server.go:1217 +0xc8f
2021-12-04T02:01:05.730Z [DEBUG] plugin.plugin: google.golang.org/grpc.(*Server).handleStream(0xc000201880, {0x1271430, 0xc00015cc00}, 0xc0000ba500, 0x0)
2021-12-04T02:01:05.730Z [DEBUG] plugin.plugin:         /home/ubuntu/go/pkg/mod/google.golang.org/grpc@v1.35.0/server.go:1540 +0xa2a
2021-12-04T02:01:05.730Z [DEBUG] plugin.plugin: google.golang.org/grpc.(*Server).serveStreams.func1.2()
2021-12-04T02:01:05.730Z [DEBUG] plugin.plugin:         /home/ubuntu/go/pkg/mod/google.golang.org/grpc@v1.35.0/server.go:878 +0x98
2021-12-04T02:01:05.730Z [DEBUG] plugin.plugin: created by google.golang.org/grpc.(*Server).serveStreams.func1
2021-12-04T02:01:05.730Z [DEBUG] plugin.plugin:         /home/ubuntu/go/pkg/mod/google.golang.org/grpc@v1.35.0/server.go:876 +0x294
2021-12-04T02:01:05.731Z [DEBUG] plugin.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"
2021-12-04T02:01:05.731Z [DEBUG] plugin: plugin process exited: path=./plugin pid=17904 error="exit status 2"
{"error":"rpc error: code = Unavailable desc = transport is closing","level":"error","msg":"error running Validate on Plugin example_plugin Policy luck_threshold\n","time":"2021-12-04T02:07:03Z"}
{"enforced":false,"kind":"Pod","level":"info","msg":"NOT ENFORCED","namespace":"default","policy":"pod_no_root_user","resource":"myapp","time":"2021-12-04T02:07:03Z","user":"kubernetes-admin"}
{"enforced":false,"kind":"Pod","level":"info","msg":"NOT ENFORCED","namespace":"default","policy":"pod_no_root_user","resource":"myapp","time":"2021-12-04T02:07:03Z","user":"kubernetes-admin"}
{"enforced":false,"kind":"Pod","level":"info","msg":"NOT ENFORCED","namespace":"default","policy":"pod_immutable_reference","resource":"myapp","time":"2021-12-04T02:07:03Z","user":"kubernetes-admin"}
{"enforced":false,"kind":"Pod","level":"info","msg":"NOT ENFORCED","namespace":"default","policy":"pod_trusted_repository","resource":"myapp","time":"2021-12-04T02:07:03Z","user":"kubernetes-admin"}
```
</details>

<details>
<summary>pod.yaml</summary>

```yaml
---
apiVersion: v1
kind: Pod
metadata:
  name: myapp
spec:
  containers:
  - name: myapp
    image: ubuntu:18.04
    command:
    - sleep
    - infinity
```

</details>

I fixed it.

## Versions

```bash
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.4", GitCommit:"e87da0bd6e03ec3fea7933c4b5263d151aafd07c", GitTreeState:"clean", BuildDate:"2021-02-18T16:12:00Z", GoVersion:"go1.15.8", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.4", GitCommit:"e87da0bd6e03ec3fea7933c4b5263d151aafd07c", GitTreeState:"clean", BuildDate:"2021-02-18T16:03:00Z", GoVersion:"go1.15.8", Compiler:"gc", Platform:"linux/amd64"}
```

```bash
$ git log -n 1 --oneline
13df1ef (HEAD -> master, tag: v3.6.1, tag: k-rail-v3.6.1, origin/master, origin/HEAD) Support all ingress versions (#128)
```