### PR TITLE
Add option to customize pod/containerSecurityContext

### DIFF
--- a/charts/k-rail/Chart.yaml
+++ b/charts/k-rail/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 name: k-rail
 description: Kubernetes security tool for policy enforcement
 home: https://github.com/cruise-automation/k-rail
-version: v3.6.1
+version: v3.6.2
 maintainers:
   - name: cruise-automation
     url: https://cruise-automation.github.io/k-rail/

--- a/charts/k-rail/templates/deployment.yaml
+++ b/charts/k-rail/templates/deployment.yaml
@@ -83,6 +83,10 @@ spec:
         checksum/tls: {{ print $ca.Cert | sha256sum }}
     spec:
       serviceAccountName: k-rail
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: k-rail
           command: ["/k-rail", "-config=/config/config.yml", "-exemptions-path-glob=/exemptions/*.yml"]
@@ -100,8 +104,10 @@ spec:
             - name: exemptions
               mountPath: /exemptions
               readOnly: true
+        {{- with .Values.containerSecurityContext }}
           securityContext:
-            readOnlyRootFilesystem: true
+          {{- toYaml . | nindent 12 }}    
+        {{- end }}
           ports:
             - containerPort: 10250
             - containerPort: 8000

--- a/charts/k-rail/values.yaml
+++ b/charts/k-rail/values.yaml
@@ -23,6 +23,13 @@ tolerations: []
 
 affinity: {}
 
+## securityContext to apply to the pod
+podSecurityContext: {}
+
+## securityContext to apply to the container
+containerSecurityContext:
+  readOnlyRootFilesystem: true
+
 # Set to the value (in seconds) which the mutatingwebhook should use for a timeout
 # for slower clusters (or larger workloads) this may need to be increased
 webhookTimeout: 1


### PR DESCRIPTION
Hey gang!

This PR adds the ability for the user to customize both the pod and the container securityContext, which may be required to make k-rail *itself* comply with other audit / admission tools, such as Kyverno :)

(We are migrating from k-rail to Kyverno, but some of its features are still desirable, such as gating image repositories!)

